### PR TITLE
Don't dump images to disk based on DEBUG define

### DIFF
--- a/libavcodec/dvbsubdec.c
+++ b/libavcodec/dvbsubdec.c
@@ -137,6 +137,9 @@ typedef struct DVBSubContext {
 
     DVBSubRegionDisplay *display_list;
     DVBSubDisplayDefinition *display_definition;
+#ifdef DEBUG
+  int dump_imgs;
+#endif
 } DVBSubContext;
 
 
@@ -1534,11 +1537,11 @@ static int save_display_set(DVBSubContext *ctx)
 
         }
 
-        snprintf(filename, sizeof(filename), "dvbs.%d", fileno_index);
-
-        png_save(ctx, filename, pbuf, width, height);
-
-        av_freep(&pbuf);
+        if (ctx->dump_imgs) {
+            snprintf(filename, sizeof(filename), "dvbs.%d", fileno_index);
+            png_save(ctx, filename, pbuf, width, height);
+            av_freep(&pbuf);
+        }
     }
 
     fileno_index++;
@@ -1730,6 +1733,9 @@ static const AVOption options[] = {
     {"compute_edt", "compute end of time using pts or timeout", OFFSET(compute_edt), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, DS},
     {"compute_clut", "compute clut when not available(-1) or only once (-2) or always(1) or never(0)", OFFSET(compute_clut), AV_OPT_TYPE_BOOL, {.i64 = -1}, -2, 1, DS},
     {"dvb_substream", "", OFFSET(substream), AV_OPT_TYPE_INT, {.i64 = -1}, -1, 63, DS},
+#ifdef DEBUG
+    { "dump_imgs", "Dump subtitle images to disk", OFFSET(dump_imgs), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, DS},
+#endif
     {NULL}
 };
 static const AVClass dvbsubdec_class = {

--- a/libavcodec/dvbsubdec.c
+++ b/libavcodec/dvbsubdec.c
@@ -66,6 +66,9 @@ typedef struct DVBSubObjectDisplay {
     struct DVBSubObjectDisplay *object_list_next;
 } DVBSubObjectDisplay;
 
+
+// Here's a little change for testing patchset versions
+
 typedef struct DVBSubObject {
     int id;
     int version;

--- a/libavcodec/dvdsubdec.c
+++ b/libavcodec/dvdsubdec.c
@@ -44,6 +44,7 @@ typedef struct DVDSubContext
   uint8_t  used_color[256];
 #ifdef DEBUG
   int sub_id;
+  int dump_imgs;
 #endif
 } DVDSubContext;
 
@@ -597,8 +598,9 @@ static int dvdsub_decode(AVCodecContext *avctx,
     ff_dlog(NULL, "start=%d ms end =%d ms\n",
             sub->start_display_time,
             sub->end_display_time);
-    ppm_save(ppm_name, sub->rects[0]->data[0],
-             sub->rects[0]->w, sub->rects[0]->h, (uint32_t*) sub->rects[0]->data[1]);
+    if (ctx->dump_imgs)
+        ppm_save(ppm_name, sub->rects[0]->data[0],
+                 sub->rects[0]->w, sub->rects[0]->h, (uint32_t*) sub->rects[0]->data[1]);
     }
 #endif
 
@@ -745,6 +747,9 @@ static const AVOption options[] = {
     { "palette", "set the global palette", OFFSET(palette_str), AV_OPT_TYPE_STRING, { .str = NULL }, 0, 0, SD },
     { "ifo_palette", "obtain the global palette from .IFO file", OFFSET(ifo_str), AV_OPT_TYPE_STRING, { .str = NULL }, 0, 0, SD },
     { "forced_subs_only", "Only show forced subtitles", OFFSET(forced_subs_only), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, SD},
+#ifdef DEBUG
+    { "dump_imgs", "Dump subtitle images to disk", OFFSET(dump_imgs), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, SD},
+#endif
     { NULL }
 };
 static const AVClass dvdsub_class = {


### PR DESCRIPTION
It's been a regular annoyance.
Introduce a debug-only parameter for this.

cc: Soft Works <softworkz@hotmail.com>