### PR TITLE
libavformat/asfdec: Fix variable types and add checks for unsupported values

### DIFF
--- a/libavformat/asf.c
+++ b/libavformat/asf.c
@@ -267,12 +267,18 @@ static int get_id3_tag(AVFormatContext *s, int len)
 }
 
 int ff_asf_handle_byte_array(AVFormatContext *s, const char *name,
-                             int val_len)
+                             uint32_t val_len)
 {
-    if (!strcmp(name, "WM/Picture")) // handle cover art
-        return asf_read_picture(s, val_len);
-    else if (!strcmp(name, "ID3")) // handle ID3 tag
-        return get_id3_tag(s, val_len);
+    if (val_len > INT32_MAX) {
+        av_log(s, AV_LOG_VERBOSE, "Unable to handle byte arrays > INT32_MAX  in tag %s.\n", name);
+        return 1;
+    }
 
+    if (!strcmp(name, "WM/Picture")) // handle cover art
+        return asf_read_picture(s, (int)val_len);
+    else if (!strcmp(name, "ID3")) // handle ID3 tag
+        return get_id3_tag(s, (int)val_len);
+
+    av_log(s, AV_LOG_VERBOSE, "Unsupported byte array in tag %s.\n", name);
     return 1;
 }

--- a/libavformat/asf.h
+++ b/libavformat/asf.h
@@ -111,7 +111,7 @@ extern const AVMetadataConv ff_asf_metadata_conv[];
  *         is unsupported by this function and 0 otherwise.
  */
 int ff_asf_handle_byte_array(AVFormatContext *s, const char *name,
-                             int val_len);
+                             uint32_t val_len);
 
 
 #define ASF_PACKET_FLAG_ERROR_CORRECTION_PRESENT 0x80 //1000 0000

--- a/libavformat/asfdec_f.c
+++ b/libavformat/asfdec_f.c
@@ -968,6 +968,7 @@ static int asf_get_packet(AVFormatContext *s, AVIOContext *pb)
             avio_seek(pb, -1, SEEK_CUR); // FIXME
         }
     } else {
+        d = e = 0;
         c = avio_r8(pb);
         if (c & 0x80) {
             rsize ++;

--- a/libavformat/asfdec_f.c
+++ b/libavformat/asfdec_f.c
@@ -280,9 +280,12 @@ static void get_tag(AVFormatContext *s, const char *key, int type, uint32_t len,
         snprintf(value, buffer_len, "%"PRIu64, num);
         break;
     }
-    case ASF_GUID:
-        av_log(s, AV_LOG_DEBUG, "Unsupported GUID value in tag %s.\n", key);
-        goto finish;
+    case ASF_GUID: {
+        ff_asf_guid g;
+        ff_get_guid(s->pb, &g);
+        snprintf(value, buffer_len, "%x", g[0]);
+        break;
+    }
     default:
         av_log(s, AV_LOG_DEBUG,
                "Unsupported value type %d in tag %s.\n", type, key);

--- a/libavformat/asfdec_f.c
+++ b/libavformat/asfdec_f.c
@@ -896,21 +896,21 @@ static int asf_read_header(AVFormatContext *s)
 }
 
 #define DO_2BITS(bits, var, defval)             \
-    switch (bits & 3) {                         \
+    switch ((bits) & 3) {                       \
     case 3:                                     \
-        var = avio_rl32(pb);                    \
+        (var) = avio_rl32(pb);                  \
         rsize += 4;                             \
         break;                                  \
     case 2:                                     \
-        var = avio_rl16(pb);                    \
+        (var) = avio_rl16(pb);                  \
         rsize += 2;                             \
         break;                                  \
     case 1:                                     \
-        var = avio_r8(pb);                      \
+        (var) = avio_r8(pb);                    \
         rsize++;                                \
         break;                                  \
     default:                                    \
-        var = defval;                           \
+        (var) = (defval);                       \
         break;                                  \
     }
 
@@ -993,9 +993,9 @@ static int asf_get_packet(AVFormatContext *s, AVIOContext *pb)
     asf->packet_flags    = c;
     asf->packet_property = d;
 
-    DO_2BITS(asf->packet_flags >> 5, packet_length, s->packet_size);
-    DO_2BITS(asf->packet_flags >> 1, padsize, 0); // sequence ignored
-    DO_2BITS(asf->packet_flags >> 3, padsize, 0); // padding length
+    DO_2BITS(asf->packet_flags >> 5, packet_length, s->packet_size)
+    DO_2BITS(asf->packet_flags >> 1, padsize, 0) // sequence ignored
+    DO_2BITS(asf->packet_flags >> 3, padsize, 0) // padding length
 
     // the following checks prevent overflows and infinite loops
     if (!packet_length || packet_length >= (1U << 29)) {
@@ -1056,9 +1056,9 @@ static int asf_read_frame_header(AVFormatContext *s, AVIOContext *pb)
     asf->stream_index     = asf->asfid2avid[num & 0x7f];
     asfst                 = &asf->streams[num & 0x7f];
     // sequence should be ignored!
-    DO_2BITS(asf->packet_property >> 4, asf->packet_seq, 0);
-    DO_2BITS(asf->packet_property >> 2, asf->packet_frag_offset, 0);
-    DO_2BITS(asf->packet_property, asf->packet_replic_size, 0);
+    DO_2BITS(asf->packet_property >> 4, asf->packet_seq, 0)
+    DO_2BITS(asf->packet_property >> 2, asf->packet_frag_offset, 0)
+    DO_2BITS(asf->packet_property, asf->packet_replic_size, 0)
     av_log(asf, AV_LOG_TRACE, "key:%d stream:%d seq:%d offset:%d replic_size:%d num:%X packet_property %X\n",
             asf->packet_key_frame, asf->stream_index, asf->packet_seq,
             asf->packet_frag_offset, asf->packet_replic_size, num, asf->packet_property);
@@ -1134,7 +1134,7 @@ static int asf_read_frame_header(AVFormatContext *s, AVIOContext *pb)
         return AVERROR_INVALIDDATA;
     }
     if (asf->packet_flags & 0x01) {
-        DO_2BITS(asf->packet_segsizetype >> 6, asf->packet_frag_size, 0); // 0 is illegal
+        DO_2BITS(asf->packet_segsizetype >> 6, asf->packet_frag_size, 0) // 0 is illegal
         if (rsize > asf->packet_size_left) {
             av_log(s, AV_LOG_ERROR, "packet_replic_size is invalid\n");
             return AVERROR_INVALIDDATA;

--- a/libavformat/asfdec_f.c
+++ b/libavformat/asfdec_f.c
@@ -323,7 +323,7 @@ static int asf_read_file_properties(AVFormatContext *s)
     return 0;
 }
 
-static int asf_read_stream_properties(AVFormatContext *s, int64_t size)
+static int asf_read_stream_properties(AVFormatContext *s, uint64_t size)
 {
     ASFContext *asf = s->priv_data;
     AVIOContext *pb = s->pb;

--- a/libavformat/asfdec_f.c
+++ b/libavformat/asfdec_f.c
@@ -1181,7 +1181,7 @@ static int asf_parse_packet(AVFormatContext *s, AVIOContext *pb, AVPacket *pkt)
             return AVERROR_EOF;
         if (asf->packet_size_left < FRAME_HEADER_SIZE ||
             asf->packet_segments < 1 && asf->packet_time_start == 0) {
-            int ret = asf->packet_size_left + asf->packet_padsize;
+            ret = asf->packet_size_left + asf->packet_padsize;
 
             if (asf->packet_size_left && asf->packet_size_left < FRAME_HEADER_SIZE)
                 av_log(s, AV_LOG_WARNING, "Skip due to FRAME_HEADER_SIZE\n");
@@ -1250,7 +1250,6 @@ static int asf_parse_packet(AVFormatContext *s, AVIOContext *pb, AVPacket *pkt)
         if (asf_st->pkt.size != asf_st->packet_obj_size ||
             // FIXME is this condition sufficient?
             asf_st->frag_offset + asf->packet_frag_size > asf_st->pkt.size) {
-            int ret;
 
             if (asf_st->pkt.data) {
                 av_log(s, AV_LOG_INFO,

--- a/libavformat/asfdec_f.c
+++ b/libavformat/asfdec_f.c
@@ -299,7 +299,7 @@ finish:
     avio_seek(s->pb, off + len, SEEK_SET);
 }
 
-static int asf_read_file_properties(AVFormatContext *s, int64_t size)
+static int asf_read_file_properties(AVFormatContext *s)
 {
     ASFContext *asf = s->priv_data;
     AVIOContext *pb = s->pb;
@@ -494,7 +494,7 @@ static int asf_read_stream_properties(AVFormatContext *s, int64_t size)
     return 0;
 }
 
-static int asf_read_ext_stream_properties(AVFormatContext *s, int64_t size)
+static int asf_read_ext_stream_properties(AVFormatContext *s)
 {
     ASFContext *asf = s->priv_data;
     AVIOContext *pb = s->pb;
@@ -554,7 +554,7 @@ static int asf_read_ext_stream_properties(AVFormatContext *s, int64_t size)
     return 0;
 }
 
-static int asf_read_content_desc(AVFormatContext *s, int64_t size)
+static int asf_read_content_desc(AVFormatContext *s)
 {
     AVIOContext *pb = s->pb;
     uint32_t len1, len2, len3, len4, len5;
@@ -573,7 +573,7 @@ static int asf_read_content_desc(AVFormatContext *s, int64_t size)
     return 0;
 }
 
-static int asf_read_ext_content_desc(AVFormatContext *s, int64_t size)
+static int asf_read_ext_content_desc(AVFormatContext *s)
 {
     AVIOContext *pb = s->pb;
     ASFContext *asf = s->priv_data;
@@ -619,7 +619,7 @@ static int asf_read_ext_content_desc(AVFormatContext *s, int64_t size)
     return 0;
 }
 
-static int asf_read_language_list(AVFormatContext *s, int64_t size)
+static int asf_read_language_list(AVFormatContext *s)
 {
     AVIOContext *pb = s->pb;
     ASFContext *asf = s->priv_data;
@@ -639,7 +639,7 @@ static int asf_read_language_list(AVFormatContext *s, int64_t size)
     return 0;
 }
 
-static int asf_read_metadata(AVFormatContext *s, int64_t size)
+static int asf_read_metadata(AVFormatContext *s)
 {
     AVIOContext *pb = s->pb;
     ASFContext *asf = s->priv_data;
@@ -693,7 +693,7 @@ static int asf_read_metadata(AVFormatContext *s, int64_t size)
     return 0;
 }
 
-static int asf_read_marker(AVFormatContext *s, int64_t size)
+static int asf_read_marker(AVFormatContext *s)
 {
     AVIOContext *pb = s->pb;
     ASFContext *asf = s->priv_data;
@@ -772,21 +772,21 @@ static int asf_read_header(AVFormatContext *s)
         if (gsize < 24)
             return AVERROR_INVALIDDATA;
         if (!ff_guidcmp(&g, &ff_asf_file_header)) {
-            ret = asf_read_file_properties(s, gsize);
+            ret = asf_read_file_properties(s);
         } else if (!ff_guidcmp(&g, &ff_asf_stream_header)) {
             ret = asf_read_stream_properties(s, gsize);
         } else if (!ff_guidcmp(&g, &ff_asf_comment_header)) {
-            asf_read_content_desc(s, gsize);
+            asf_read_content_desc(s);
         } else if (!ff_guidcmp(&g, &ff_asf_language_guid)) {
-            asf_read_language_list(s, gsize);
+            asf_read_language_list(s);
         } else if (!ff_guidcmp(&g, &ff_asf_extended_content_header)) {
-            asf_read_ext_content_desc(s, gsize);
+            asf_read_ext_content_desc(s);
         } else if (!ff_guidcmp(&g, &ff_asf_metadata_header)) {
-            asf_read_metadata(s, gsize);
+            asf_read_metadata(s);
         } else if (!ff_guidcmp(&g, &ff_asf_metadata_library_header)) {
-            asf_read_metadata(s, gsize);
+            asf_read_metadata(s);
         } else if (!ff_guidcmp(&g, &ff_asf_ext_stream_header)) {
-            asf_read_ext_stream_properties(s, gsize);
+            asf_read_ext_stream_properties(s);
 
             // there could be an optional stream properties object to follow
             // if so the next iteration will pick it up
@@ -796,7 +796,7 @@ static int asf_read_header(AVFormatContext *s)
             avio_skip(pb, 6);
             continue;
         } else if (!ff_guidcmp(&g, &ff_asf_marker_header)) {
-            asf_read_marker(s, gsize);
+            asf_read_marker(s);
         } else if (avio_feof(pb)) {
             return AVERROR_EOF;
         } else {


### PR DESCRIPTION
Fix variable types and add checks for unsupported values and fix other issues.