### PR TITLE
avcodec/dvdsubdec: fix incorrect yellow appearance of dvd subtitles

### DIFF
--- a/libavcodec/dvdsubdec.c
+++ b/libavcodec/dvdsubdec.c
@@ -400,7 +400,7 @@ static int decode_dvd_subtitles(DVDSubContext *ctx, AVSubtitle *sub_header,
                 } else {
                     sub_header->rects[0]->nb_colors = 4;
                     guess_palette(ctx, (uint32_t*)sub_header->rects[0]->data[1],
-                                  0xffff00);
+                                  0xffffff);
                 }
                 sub_header->rects[0]->x = x1;
                 sub_header->rects[0]->y = y1;


### PR DESCRIPTION
Fixes an age-old bug in decoding DVD subtitles. 

Ever wondered why certain DVD subtitles are shown in yellow color when ffmpeg
is involved...

cc: Soft Works <softworkz@hotmail.com>
cc: Scott Theisen <scott.the.elm@gmail.com>