### PR TITLE
avformat/hlsenc: Fix path handling on Windows

### DIFF
--- a/libavformat/hlsenc.c
+++ b/libavformat/hlsenc.c
@@ -3028,6 +3028,10 @@ static int hls_init(AVFormatContext *s)
                 }
 
                 p = strrchr(vs->m3u8_name, '/');
+#if HAVE_DOS_PATHS
+                p = FFMAX(p, strrchr(vs->m3u8_name, '\\'));
+#endif
+
                 if (p) {
                     char tmp = *(++p);
                     *p = '\0';


### PR DESCRIPTION
Handling for DOS path separators was missing

cc: Andreas Rheinhardt <andreas.rheinhardt@outlook.com>
cc: Soft Works <softworkz@hotmail.com>