### PR TITLE
libavutil/tests/md5: Avoid warnings

### DIFF
--- a/libavutil/tests/md5.c
+++ b/libavutil/tests/md5.c
@@ -33,8 +33,8 @@ int main(void)
 {
     uint8_t md5val[16];
     int i;
-    volatile uint8_t in[1000]; // volatile to workaround http://llvm.org/bugs/show_bug.cgi?id=20849
-    // FIXME remove volatile once it has been fixed and all fate clients are updated
+
+    uint8_t in[1000];
 
     for (i = 0; i < 1000; i++)
         in[i] = i * i;


### PR DESCRIPTION
Those are always showing up on Patchwork
when FATE tests are failing, covering
some possibly more useful information.

v4:
- The problem still exists:    
  https://patchwork.ffmpeg.org/check/62130/    
- as was suggested, this patch removes the volatile keyword altogether     

cc: James Almer <jamrial@gmail.com>
cc: Soft Works <softworkz@hotmail.com>
cc: Carl Eugen Hoyos <ceffmpeg@gmail.com>
cc: Marton Balint <cus@passwd.hu>