### PR TITLE
lavc/videotoolboxdec: improve HEVC stream compatibility

### DIFF
--- a/libavcodec/h264_ps.c
+++ b/libavcodec/h264_ps.c
@@ -351,6 +351,10 @@ int ff_h264_decode_seq_parameter_set(GetBitContext *gb, AVCodecContext *avctx,
     }
     memcpy(sps->data, gb->buffer, sps->data_size);
 
+    // Re-add the removed stop bit (may be used by hwaccels).
+    if (!(gb->size_in_bits & 7) && sps->data_size < sizeof(sps->data))
+        sps->data[sps->data_size++] = 0x80;
+
     profile_idc           = get_bits(gb, 8);
     constraint_set_flags |= get_bits1(gb) << 0;   // constraint_set0_flag
     constraint_set_flags |= get_bits1(gb) << 1;   // constraint_set1_flag
@@ -774,6 +778,10 @@ int ff_h264_decode_picture_parameter_set(GetBitContext *gb, AVCodecContext *avct
         pps->data_size = sizeof(pps->data);
     }
     memcpy(pps->data, gb->buffer, pps->data_size);
+
+    // Re-add the removed stop bit (may be used by hwaccels).
+    if (!(bit_length & 7) && pps->data_size < sizeof(pps->data))
+        pps->data[pps->data_size++] = 0x80;
 
     pps->sps_id = get_ue_golomb_31(gb);
     if ((unsigned)pps->sps_id >= MAX_SPS_COUNT ||

--- a/libavcodec/videotoolbox.c
+++ b/libavcodec/videotoolbox.c
@@ -328,13 +328,13 @@ CFDataRef ff_videotoolbox_hvcc_extradata_create(AVCodecContext *avctx)
      * bit(5) reserved = ‘11111’b;
      * unsigned int(3) bitDepthLumaMinus8;
      */
-    AV_W8(p + 17, (sps->bit_depth - 8) | 0xfc);
+    AV_W8(p + 17, (sps->bit_depth - 8) | 0xf8);
 
     /*
      * bit(5) reserved = ‘11111’b;
      * unsigned int(3) bitDepthChromaMinus8;
      */
-    AV_W8(p + 18, (sps->bit_depth_chroma - 8) | 0xfc);
+    AV_W8(p + 18, (sps->bit_depth_chroma - 8) | 0xf8);
 
     /* bit(16) avgFrameRate; */
     AV_WB16(p + 19, 0);

--- a/libavcodec/videotoolbox.c
+++ b/libavcodec/videotoolbox.c
@@ -691,7 +691,7 @@ static void videotoolbox_decoder_callback(void *opaque,
     }
 
     if (!image_buffer) {
-        av_log(avctx, AV_LOG_DEBUG, "vt decoder cb: output image buffer is null\n");
+        av_log(avctx, status ? AV_LOG_WARNING : AV_LOG_DEBUG, "vt decoder cb: output image buffer is null: %i\n", status);
         return;
     }
 

--- a/libavcodec/videotoolbox.c
+++ b/libavcodec/videotoolbox.c
@@ -166,14 +166,13 @@ static int escape_ps(uint8_t* dst, const uint8_t* src, int src_size)
             src[i + 2] <= 0x03) {
             if (dst) {
                 *p++ = src[i++];
-                *p++ = src[i++];
+                *p++ = src[i];
                 *p++ = 0x03;
             } else {
-                i += 2;
+                i++;
             }
             size++;
-        }
-        if (dst)
+        } else if (dst)
             *p++ = src[i];
     }
 

--- a/libavcodec/videotoolbox.c
+++ b/libavcodec/videotoolbox.c
@@ -246,7 +246,7 @@ CFDataRef ff_videotoolbox_hvcc_extradata_create(AVCodecContext *avctx)
     for (i = 0; i < HEVC_MAX_##T##PS_COUNT; i++) { \
         if (h->ps.t##ps_list[i]) { \
             const HEVC##T##PS *lps = (const HEVC##T##PS *)h->ps.t##ps_list[i]->data; \
-            vt_extradata_size += 2 + lps->data_size; \
+            vt_extradata_size += 2 + escape_ps(NULL, lps->data, lps->data_size); \
             num_##t##ps++; \
         } \
     }
@@ -369,11 +369,11 @@ CFDataRef ff_videotoolbox_hvcc_extradata_create(AVCodecContext *avctx)
     for (i = 0; i < HEVC_MAX_##T##PS_COUNT; i++) { \
         if (h->ps.t##ps_list[i]) { \
             const HEVC##T##PS *lps = (const HEVC##T##PS *)h->ps.t##ps_list[i]->data; \
+            int size = escape_ps(p + 2, lps->data, lps->data_size); \
             /* unsigned int(16) nalUnitLength; */ \
-            AV_WB16(p, lps->data_size); \
+            AV_WB16(p, size); \
             /* bit(8*nalUnitLength) nalUnit; */ \
-            memcpy(p + 2, lps->data, lps->data_size); \
-            p += 2 + lps->data_size; \
+            p += 2 + size; \
         } \
     }
 

--- a/libavcodec/videotoolbox.c
+++ b/libavcodec/videotoolbox.c
@@ -273,7 +273,16 @@ CFDataRef ff_videotoolbox_hvcc_extradata_create(AVCodecContext *avctx)
                  ptlc.profile_idc);
 
     /* unsigned int(32) general_profile_compatibility_flags; */
-    memcpy(p + 2, ptlc.profile_compatibility_flag, 4);
+    for (i = 0; i < 4; i++) {
+        AV_W8(p + 2 + i, ptlc.profile_compatibility_flag[i * 8] << 7 |
+                         ptlc.profile_compatibility_flag[i * 8 + 1] << 6 |
+                         ptlc.profile_compatibility_flag[i * 8 + 2] << 5 |
+                         ptlc.profile_compatibility_flag[i * 8 + 3] << 4 |
+                         ptlc.profile_compatibility_flag[i * 8 + 4] << 3 |
+                         ptlc.profile_compatibility_flag[i * 8 + 5] << 2 |
+                         ptlc.profile_compatibility_flag[i * 8 + 6] << 1 |
+                         ptlc.profile_compatibility_flag[i * 8 + 7]);
+    }
 
     /* unsigned int(48) general_constraint_indicator_flags; */
     AV_W8(p + 6, ptlc.progressive_source_flag    << 7 |


### PR DESCRIPTION
- Improve logging in error conditions
- Improve NAL-escape function behavior
- Fix some syntax issues in hvcc
- Correctly escape NALs in hvcc
- Make sure we expose the stop bits in H264 PS NALs

These changes fix support for several samples I've found or generated locally.

cc: Andreas Rheinhardt <andreas.rheinhardt@outlook.com>