### PR TITLE
fftools/opt_common: add missing include of avf/version.h

### DIFF
--- a/fftools/opt_common.c
+++ b/fftools/opt_common.c
@@ -51,6 +51,9 @@
 #include "libavdevice/avdevice.h"
 #include "libavdevice/version.h"
 
+#include "libavfilter/avfilter.h"
+#include "libavfilter/version.h"
+
 #include "libswscale/swscale.h"
 #include "libswscale/version.h"
 


### PR DESCRIPTION
MSVC compiler complains without this include

v2: also include avfilter.h as suggested    
v3: adjust commit message as suggested by Andreas    

cc: Andreas Rheinhardt <andreas.rheinhardt@outlook.com>
cc: Soft Works <softworkz@hotmail.com>