### PR TITLE
avcodec/libx264: don't define X264_API_IMPORTS when compiling static

### DIFF
--- a/libavcodec/libx264.c
+++ b/libavcodec/libx264.c
@@ -37,7 +37,7 @@
 #include "atsc_a53.h"
 #include "sei.h"
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(DISABLE_X264_API_IMPORTS)
 #define X264_API_IMPORTS 1
 #endif
 


### PR DESCRIPTION
The definition of X264_API_IMPORTS is required for shared linking
(when MSVC is used) but it must not be defined in case of static
builds as is stated in x264.h:

v2 use custom macro for control, so there's no mechanism imposed
    and no change as long as that macro isn't explicitly defined    

cc: Derek Buitenhuis <derek.buitenhuis@gmail.com>
cc: Soft Works <softworkz@hotmail.com>
cc: Timo Rothenpieler <timo@rothenpieler.org>
cc: Hendrik Leppkes <h.leppkes@gmail.com>
cc: Martin Storsjö <martin@martin.st>