### PR TITLE
libx264: Set min build version to 158

### DIFF
--- a/configure
+++ b/configure
@@ -6658,10 +6658,10 @@ enabled libvpx            && {
 enabled libwebp           && {
     enabled libwebp_encoder      && require_pkg_config libwebp "libwebp >= 0.2.0" webp/encode.h WebPGetEncoderVersion
     enabled libwebp_anim_encoder && check_pkg_config libwebp_anim_encoder "libwebpmux >= 0.4.0" webp/mux.h WebPAnimEncoderOptionsInit; }
-enabled libx264           && { check_pkg_config libx264 x264 "stdint.h x264.h" x264_encoder_encode ||
-                               { require libx264 "stdint.h x264.h" x264_encoder_encode "-lx264 $pthreads_extralibs $libm_extralibs" &&
-                                 warn "using libx264 without pkg-config"; } } &&
-                             require_cpp_condition libx264 x264.h "X264_BUILD >= 118" &&
+enabled libx264           && check_pkg_config libx264 x264 "stdint.h x264.h" x264_encoder_encode &&
+                             require_cpp_condition libx264 x264.h "X264_BUILD >= 118" && {
+                             [ "$toolchain" != "msvc" ] ||
+                             require_cpp_condition libx264 x264.h "X264_BUILD >= 158"; } &&
                              check_cpp_condition libx262 x264.h "X264_MPEG2"
 enabled libx265           && require_pkg_config libx265 x265 x265.h x265_api_get &&
                              require_cpp_condition libx265 x265.h "X265_BUILD >= 70"

--- a/libavcodec/libx264.c
+++ b/libavcodec/libx264.c
@@ -37,10 +37,6 @@
 #include "atsc_a53.h"
 #include "sei.h"
 
-#if defined(_MSC_VER)
-#define X264_API_IMPORTS 1
-#endif
-
 #include <x264.h>
 #include <float.h>
 #include <math.h>


### PR DESCRIPTION
I'm submitting this patch on behalf of Matt with his permission.

There was agreement that the >= 158 version requirement should 
be applied to MSVC builds only. 

v2: restrict the version requirement to msvc builds    
v3: fix unintended author change    
v4: add missing braces    
v5: fixed condition (again ;-)    
v6: hope I got it now..    
v7: add comment about dropping non-pkg-conf check, re-add libx262 check

cc: Andreas Rheinhardt <andreas.rheinhardt@outlook.com>
cc: Soft Works <softworkz@hotmail.com>
cc: Michael Niedermayer <michael@niedermayer.cc>
cc: Marton Balint <cus@passwd.hu>