### PR TITLE
tests/fate/vcodec: Limit mem alignment for vsynth..mpeg2-422 tests

### DIFF
--- a/tests/fate/vcodec.mak
+++ b/tests/fate/vcodec.mak
@@ -264,7 +264,9 @@ fate-vsynth%-mpeg2-422:          ENCOPTS = -b:v 1000k                   \
                                            -mpv_flags +qp_rd+mv0        \
                                            -intra_vlc 1                 \
                                            -mbd rd                      \
-                                           -pix_fmt yuv422p
+                                           -pix_fmt yuv422p             \
+										   $(if $(HAVE_MMX), -cpuflags -avx512 )
+										   
 fate-vsynth%-mpeg2-idct-int:     ENCOPTS = -qscale 10 -idct int -dct int
 fate-vsynth%-mpeg2-ilace:        ENCOPTS = -qscale 10 -flags +ildct+ilme
 fate-vsynth%-mpeg2-ivlc-qprd:    ENCOPTS = -b:v 500k                    \


### PR DESCRIPTION
Fix FATE tests which are failing on newer x86 CPUs.

v2: Add the flag on x86 platforms only
cc: Kieran Kunhya <kierank@obe.tv>
cc: Soft Works <softworkz@hotmail.com>
cc: Paul B Mahol <onemda@gmail.com>
cc: Andreas Rheinhardt <andreas.rheinhardt@outlook.com>