### PR TITLE
fftools/fopen_utf8: support long paths on Windows for fftools

### DIFF
--- a/fftools/fopen_utf8.h
+++ b/fftools/fopen_utf8.h
@@ -35,7 +35,7 @@ static inline FILE *fopen_utf8(const char *path_utf8, const char *mode)
     FILE *f;
 
     /* convert UTF-8 to wide chars */
-    if (utf8towchar(path_utf8, &path_w)) /* This sets errno on error. */
+    if (get_extended_win32_path(path_utf8, &path_w)) /* This sets errno on error. */
         return NULL;
     if (!path_w)
         goto fallback;


### PR DESCRIPTION
After Nil's patchset, this is probably the final missing bit.

Signed-off-by: softworkz <softworkz@hotmail.com>
cc: Martin Storsjö <martin@martin.st>