### PR TITLE
libavformat/mov: Add support for exporting poster time.

### DIFF
--- a/doc/demuxers.texi
+++ b/doc/demuxers.texi
@@ -749,6 +749,12 @@ cast to int32 are used to adjust onward dts.
 
 Unit is the track time scale. Range is 0 to UINT_MAX. Default is @code{UINT_MAX - 48000*10} which allows upto
 a 10 second dts correction for 48 kHz audio streams while accommodating 99.9% of @code{uint32} range.
+
+@item poster_time_location
+Export the poster_time_location if available.
+The poster_time_location is calculated using the poster_time / time_scale = X seconds.
+The value of poster_time_location indicates where in the video the poster frame is.
+Default is false.
 @end table
 
 @subsection Audible AAX

--- a/doc/demuxers.texi
+++ b/doc/demuxers.texi
@@ -750,10 +750,10 @@ cast to int32 are used to adjust onward dts.
 Unit is the track time scale. Range is 0 to UINT_MAX. Default is @code{UINT_MAX - 48000*10} which allows upto
 a 10 second dts correction for 48 kHz audio streams while accommodating 99.9% of @code{uint32} range.
 
-@item poster_time_location
+@item export_poster_time_location
 Export the poster_time_location if available.
 The poster_time_location is calculated using the poster_time / time_scale = X seconds.
-The value of poster_time_location indicates where in the video the poster frame is.
+The value of the poster_time_location key indicates where in the video the poster frame is.
 Default is false.
 @end table
 

--- a/libavformat/isom.h
+++ b/libavformat/isom.h
@@ -326,7 +326,7 @@ typedef struct MOVContext {
         int64_t extent_offset;
     } *avif_info;
     int avif_info_size;
-    int poster_time_location;
+    int export_poster_time_location;
 } MOVContext;
 
 int ff_mp4_read_descr_len(AVIOContext *pb);

--- a/libavformat/isom.h
+++ b/libavformat/isom.h
@@ -326,6 +326,7 @@ typedef struct MOVContext {
         int64_t extent_offset;
     } *avif_info;
     int avif_info_size;
+    int poster_time_location;
 } MOVContext;
 
 int ff_mp4_read_descr_len(AVIOContext *pb);

--- a/libavformat/mov.c
+++ b/libavformat/mov.c
@@ -1501,6 +1501,7 @@ static int mov_read_mvhd(MOVContext *c, AVIOContext *pb, MOVAtom atom)
 {
     int i;
     int64_t creation_time;
+    int32_t poster_time;
     int version = avio_r8(pb); /* version */
     avio_rb24(pb); /* flags */
 
@@ -1535,11 +1536,19 @@ static int mov_read_mvhd(MOVContext *c, AVIOContext *pb, MOVAtom atom)
 
     avio_rb32(pb); /* preview time */
     avio_rb32(pb); /* preview duration */
-    avio_rb32(pb); /* poster time */
+    poster_time = avio_rb32(pb); /* poster time */
     avio_rb32(pb); /* selection time */
     avio_rb32(pb); /* selection duration */
     avio_rb32(pb); /* current time */
     avio_rb32(pb); /* next track ID */
+
+    if(c->poster_time_location && poster_time && c->time_scale && c->time_scale > 0) {
+        av_log(c->fc, AV_LOG_TRACE, "poster_time = %i, time_scale = %i\n", poster_time, c->time_scale);
+        char buffer[32];
+        int poster_time_location = poster_time / c->time_scale;
+        snprintf(buffer, sizeof(buffer), "%i", poster_time_location);
+        av_dict_set(&c->fc->metadata, "poster_time_location", buffer, 0);
+    }
 
     return 0;
 }
@@ -9114,7 +9123,7 @@ static const AVOption mov_options[] = {
     { "enable_drefs", "Enable external track support.", OFFSET(enable_drefs), AV_OPT_TYPE_BOOL,
         {.i64 = 0}, 0, 1, FLAGS },
     { "max_stts_delta", "treat offsets above this value as invalid", OFFSET(max_stts_delta), AV_OPT_TYPE_INT, {.i64 = UINT_MAX-48000*10 }, 0, UINT_MAX, .flags = AV_OPT_FLAG_DECODING_PARAM },
-
+    { "poster_time_location", "Export the poster time location.", OFFSET(poster_time_location), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, FLAGS | AV_OPT_FLAG_EXPORT },
     { NULL },
 };
 

--- a/libavformat/mov.c
+++ b/libavformat/mov.c
@@ -1542,7 +1542,7 @@ static int mov_read_mvhd(MOVContext *c, AVIOContext *pb, MOVAtom atom)
     avio_rb32(pb); /* current time */
     avio_rb32(pb); /* next track ID */
 
-    if(c->poster_time_location && poster_time && c->time_scale && c->time_scale > 0) {
+    if(c->export_poster_time_location && poster_time && c->time_scale && c->time_scale > 0) {
         av_log(c->fc, AV_LOG_TRACE, "poster_time = %i, time_scale = %i\n", poster_time, c->time_scale);
         char buffer[32];
         int poster_time_location = poster_time / c->time_scale;
@@ -9123,7 +9123,7 @@ static const AVOption mov_options[] = {
     { "enable_drefs", "Enable external track support.", OFFSET(enable_drefs), AV_OPT_TYPE_BOOL,
         {.i64 = 0}, 0, 1, FLAGS },
     { "max_stts_delta", "treat offsets above this value as invalid", OFFSET(max_stts_delta), AV_OPT_TYPE_INT, {.i64 = UINT_MAX-48000*10 }, 0, UINT_MAX, .flags = AV_OPT_FLAG_DECODING_PARAM },
-    { "poster_time_location", "Export the poster time location.", OFFSET(poster_time_location), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, FLAGS | AV_OPT_FLAG_EXPORT },
+    { "export_poster_time_location", "Export the poster time location.", OFFSET(export_poster_time_location), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, FLAGS | AV_OPT_FLAG_EXPORT },
     { NULL },
 };
 


### PR DESCRIPTION
Export the poster_time_location if available.
The poster_time_location is calculated using
the poster_time / time_scale = X seconds.
The value of poster_time_location indicates
where in the video the poster frame is.

Addresses feedback
from https://www.mail-archive.com/ffmpeg-devel@ffmpeg.org/msg138122.html.

Signed-off-by: Bryce Chester Newman bryce.newman@gettyimages.com
cc: Bryce Newman <bryce.newman@gettyimages.com>
cc: "zhilizhao(赵志立)" <quinkblack@foxmail.com>