### PR TITLE
configure: check for sysctl.h explicitly

### DIFF
--- a/configure
+++ b/configure
@@ -6282,7 +6282,7 @@ check_func  setrlimit
 check_struct "sys/stat.h" "struct stat" st_mtim.tv_nsec -D_BSD_SOURCE
 check_func  strerror_r
 check_func  sysconf
-check_func  sysctl
+check_func_headers sys/sysctl.h sysctl
 check_func  usleep
 
 check_func_headers conio.h kbhit


### PR DESCRIPTION
HAVE_SYSCTL is used to guard #include <sys/sysctl.h>, so make sure we only define it when that header is present.

In recent glibc, the header was removed:
https://sourceware.org/pipermail/glibc-cvs/2020q2/069366.html

Signed-off-by: Aman Karmani <aman@tmm1.net>
cc: Andreas Rheinhardt <andreas.rheinhardt@outlook.com>
cc: Aman Karmani <ffmpeg@tmm1.net>