### PR TITLE
avformat/dump: Print stream start offsets for input streams

### DIFF
--- a/libavformat/dump.c
+++ b/libavformat/dump.c
@@ -678,6 +678,11 @@ FF_ENABLE_DEPRECATION_WARNINGS
             print_fps(1 / av_q2d(st->time_base), "tbn", log_level);
     }
 
+    if (st->start_time != AV_NOPTS_VALUE && st->start_time != 0 && st->time_base.den && st->time_base.num) {
+        const double stream_start = av_q2d(st->time_base) * st->start_time;
+        av_log(NULL, AV_LOG_INFO, ", Start-Time %.3fs", stream_start);
+    }
+
     dump_disposition(st->disposition, log_level);
     av_log(NULL, log_level, "\n");
 


### PR DESCRIPTION
Seeing the offset of video and audio streams to each other is often
a useful metric in diagnosing and understanding issues with playback
or transcoding.
This commit adds those offsets to the stream info print.