### PR TITLE
ffmpeg/repo: Add dot-folders in the repository root to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@
 /tools/python/__pycache__/
 /libavcodec/vulkan/*.c
 /libavfilter/vulkan/*.c
+/.*/


### PR DESCRIPTION
Those are often used by IDEs and FFmpeg doesn't have
any such folders in the repo.

Signed-off-by: softworkz <softworkz@hotmail.com>