### PR TITLE
Execution Graph Printing

### DIFF
--- a/configure
+++ b/configure
@@ -523,6 +523,7 @@ Developer options (useful when working on FFmpeg itself):
   --enable-macos-kperf     enable macOS kperf (private) API
   --disable-large-tests    disable tests that use a large amount of memory
   --disable-ptx-compression don't compress CUDA PTX code even when possible
+  --disable-resource-compression don't compress resources even when possible
   --disable-version-tracking don't include the git/release version in the build
 
 NOTE: Object files are built at the place where configure is launched.
@@ -2123,6 +2124,7 @@ CONFIG_LIST="
     ossfuzz
     pic
     ptx_compression
+    resource_compression
     thumb
     valgrind_backtrace
     xmm_clobber_test
@@ -4179,6 +4181,7 @@ enable iamf
 enable large_tests
 enable optimizations
 enable ptx_compression
+enable resource_compression
 enable runtime_cpudetect
 enable safe_bitstream_reader
 enable static
@@ -6903,6 +6906,8 @@ EOF
 [ -x "$(command -v gzip)" ] && enable gzip
 
 enabled zlib_gzip && enabled gzip || disable ptx_compression
+
+enabled zlib_gzip && enabled gzip || disable resource_compression
 
 # On some systems dynamic loading requires no extra linker flags
 check_lib libdl dlfcn.h "dlopen dlsym" || check_lib libdl dlfcn.h "dlopen dlsym" -ldl

--- a/doc/APIchanges
+++ b/doc/APIchanges
@@ -2,6 +2,9 @@ The last version increases of all libraries were on 2025-03-28
 
 API changes, most recent first:
 
+2025-02-xx - xxxxxxxxxx - lavfi 10.10.100 - avfilter.h
+  Add avfilter_link_get_hw_frames_ctx().
+
 2025-04-21 - xxxxxxxxxx - lavu 60.2.100 - log.h
   Add AV_CLASS_CATEGORY_HWDEVICE.
 

--- a/doc/ffmpeg.texi
+++ b/doc/ffmpeg.texi
@@ -1394,6 +1394,16 @@ It is on by default, to explicitly disable it you need to specify @code{-nostats
 @item -stats_period @var{time} (@emph{global})
 Set period at which encoding progress/statistics are updated. Default is 0.5 seconds.
 
+@item -print_graphs (@emph{global})
+Prints execution graph details to stderr in the format set via -print_graphs_format.
+
+@item -print_graphs_file @var{filename} (@emph{global})
+Writes execution graph details to the specified file in the format set via -print_graphs_format.
+
+@item -print_graphs_format @var{format} (@emph{global})
+Sets the output format (available formats are: default, compact, csv, flat, ini, json, xml, mermaid, mermaidhtml)
+The default format is json.
+
 @item -progress @var{url} (@emph{global})
 Send program-friendly progress information to @var{url}.
 

--- a/doc/ffmpeg.texi
+++ b/doc/ffmpeg.texi
@@ -1404,6 +1404,10 @@ Writes execution graph details to the specified file in the format set via -prin
 Sets the output format (available formats are: default, compact, csv, flat, ini, json, xml, mermaid, mermaidhtml)
 The default format is json.
 
+@item -sg (@emph{global})
+Writes the execution graph to a temporary html file (mermaidhtml format) and 
+tries to launch it in the default browser.
+
 @item -progress @var{url} (@emph{global})
 Send program-friendly progress information to @var{url}.
 

--- a/ffbuild/common.mak
+++ b/ffbuild/common.mak
@@ -139,6 +139,44 @@ else
 	$(BIN2C) $(patsubst $(SRC_PATH)/%,$(SRC_LINK)/%,$<) $@ $(subst .,_,$(basename $(notdir $@)))
 endif
 
+# 1) Preprocess CSS to a minified version
+%.css.min: %.css
+	# Must start with a tab in the real Makefile
+	sed 's!/\\*.*\\*/!!g' $< \
+	| tr '\n' ' ' \
+	| tr -s ' ' \
+	| sed 's/^ //; s/ $$//' \
+	> $@
+
+ifdef CONFIG_RESOURCE_COMPRESSION
+
+# 2) Gzip the minified CSS
+%.css.min.gz: %.css.min
+	$(M)gzip -nc9 $< > $@
+
+# 3) Convert the gzipped CSS to a .c array
+%.css.c: %.css.min.gz $(BIN2CEXE)
+	$(BIN2C) $< $@ $(subst .,_,$(basename $(notdir $@)))
+
+# 4) Gzip the HTML file (no minification needed)
+%.html.gz: %.html
+	$(M)gzip -nc9 $< > $@
+
+# 5) Convert the gzipped HTML to a .c array
+%.html.c: %.html.gz $(BIN2CEXE)
+	$(BIN2C) $< $@ $(subst .,_,$(basename $(notdir $@)))
+
+else   # NO COMPRESSION
+
+# 2) Convert the minified CSS to a .c array
+%.css.c: %.css.min $(BIN2CEXE)
+	$(BIN2C) $< $@ $(subst .,_,$(basename $(notdir $@)))
+
+# 3) Convert the plain HTML to a .c array
+%.html.c: %.html $(BIN2CEXE)
+	$(BIN2C) $< $@ $(subst .,_,$(basename $(notdir $@)))
+endif
+
 clean::
 	$(RM) $(BIN2CEXE) $(CLEANSUFFIXES:%=ffbuild/%)
 
@@ -191,9 +229,10 @@ SKIPHEADERS += $(ARCH_HEADERS:%=$(ARCH)/%) $(SKIPHEADERS-)
 SKIPHEADERS := $(SKIPHEADERS:%=$(SUBDIR)%)
 HOBJS        = $(filter-out $(SKIPHEADERS:.h=.h.o),$(ALLHEADERS:.h=.h.o))
 PTXOBJS      = $(filter %.ptx.o,$(OBJS))
+RESOURCEOBJS = $(filter %.css.o %.html.o,$(OBJS))
 $(HOBJS):     CCFLAGS += $(CFLAGS_HEADERS)
 checkheaders: $(HOBJS)
-.SECONDARY:   $(HOBJS:.o=.c) $(PTXOBJS:.o=.c) $(PTXOBJS:.o=.gz) $(PTXOBJS:.o=)
+.SECONDARY:   $(HOBJS:.o=.c) $(PTXOBJS:.o=.c) $(PTXOBJS:.o=.gz) $(PTXOBJS:.o=) $(RESOURCEOBJS:.o=.c) $(RESOURCEOBJS:%.css.o=%.css.min) $(RESOURCEOBJS:%.css.o=%.css.min.gz) $(RESOURCEOBJS:%.html.o=%.html.gz) $(RESOURCEOBJS:.o=)
 
 alltools: $(TOOLS)
 
@@ -214,7 +253,7 @@ $(TOOLOBJS): | tools
 
 OUTDIRS := $(OUTDIRS) $(dir $(OBJS) $(HOBJS) $(HOSTOBJS) $(SLIBOBJS) $(SHLIBOBJS) $(STLIBOBJS) $(TESTOBJS))
 
-CLEANSUFFIXES     = *.d *.gcda *.gcno *.h.c *.ho *.map *.o *.objs *.pc *.ptx *.ptx.gz *.ptx.c *.ver *.version *$(DEFAULT_X86ASMD).asm *~ *.ilk *.pdb
+CLEANSUFFIXES     = *.d *.gcda *.gcno *.h.c *.ho *.map *.o *.objs *.pc *.ptx *.ptx.gz *.ptx.c *.ver *.version *.html.gz *.html.c *.css.gz *.css.c  *$(DEFAULT_X86ASMD).asm *~ *.ilk *.pdb
 LIBSUFFIXES       = *.a *.lib *.so *.so.* *.dylib *.dll *.def *.dll.a
 
 define RULES

--- a/fftools/Makefile
+++ b/fftools/Makefile
@@ -9,6 +9,8 @@ AVBASENAMES  = ffmpeg ffplay ffprobe
 ALLAVPROGS   = $(AVBASENAMES:%=%$(PROGSSUF)$(EXESUF))
 ALLAVPROGS_G = $(AVBASENAMES:%=%$(PROGSSUF)_g$(EXESUF))
 
+include $(SRC_PATH)/fftools/resources/Makefile
+
 OBJS-ffmpeg +=                  \
     fftools/ffmpeg_dec.o        \
     fftools/ffmpeg_demux.o      \
@@ -19,8 +21,21 @@ OBJS-ffmpeg +=                  \
     fftools/ffmpeg_mux_init.o   \
     fftools/ffmpeg_opt.o        \
     fftools/ffmpeg_sched.o      \
+    fftools/graph/graphprint.o        \
     fftools/sync_queue.o        \
     fftools/thread_queue.o      \
+    fftools/textformat/avtextformat.o \
+    fftools/textformat/tf_compact.o   \
+    fftools/textformat/tf_default.o   \
+    fftools/textformat/tf_flat.o      \
+    fftools/textformat/tf_ini.o       \
+    fftools/textformat/tf_json.o      \
+    fftools/textformat/tf_mermaid.o   \
+    fftools/textformat/tf_xml.o       \
+    fftools/textformat/tw_avio.o      \
+    fftools/textformat/tw_buffer.o    \
+    fftools/textformat/tw_stdout.o    \
+    $(OBJS-resman)                    \
 
 OBJS-ffprobe +=                       \
     fftools/textformat/avtextformat.o \
@@ -29,10 +44,12 @@ OBJS-ffprobe +=                       \
     fftools/textformat/tf_flat.o      \
     fftools/textformat/tf_ini.o       \
     fftools/textformat/tf_json.o      \
+    fftools/textformat/tf_mermaid.o   \
     fftools/textformat/tf_xml.o       \
     fftools/textformat/tw_avio.o      \
     fftools/textformat/tw_buffer.o    \
     fftools/textformat/tw_stdout.o    \
+    $(OBJS-resman)                    \
 
 OBJS-ffplay += fftools/ffplay_renderer.o
 
@@ -42,7 +59,7 @@ ifdef HAVE_GNU_WINDRES
 OBJS-$(1) += fftools/fftoolsres.o
 endif
 $(1)$(PROGSSUF)_g$(EXESUF): $$(OBJS-$(1))
-$$(OBJS-$(1)): | fftools fftools/textformat fftools/resources
+$$(OBJS-$(1)): | fftools fftools/textformat fftools/resources fftools/graph
 $$(OBJS-$(1)): CFLAGS  += $(CFLAGS-$(1))
 $(1)$(PROGSSUF)_g$(EXESUF): LDFLAGS += $(LDFLAGS-$(1))
 $(1)$(PROGSSUF)_g$(EXESUF): FF_EXTRALIBS += $(EXTRALIBS-$(1))
@@ -57,6 +74,7 @@ fftools/ffprobe.o fftools/cmdutils.o: libavutil/ffversion.h | fftools
 OUTDIRS += fftools
 OUTDIRS += fftools/textformat
 OUTDIRS += fftools/resources
+OUTDIRS += fftools/graph
 
 ifdef AVPROGS
 install: install-progs install-data

--- a/fftools/Makefile
+++ b/fftools/Makefile
@@ -42,7 +42,7 @@ ifdef HAVE_GNU_WINDRES
 OBJS-$(1) += fftools/fftoolsres.o
 endif
 $(1)$(PROGSSUF)_g$(EXESUF): $$(OBJS-$(1))
-$$(OBJS-$(1)): | fftools fftools/textformat
+$$(OBJS-$(1)): | fftools fftools/textformat fftools/resources
 $$(OBJS-$(1)): CFLAGS  += $(CFLAGS-$(1))
 $(1)$(PROGSSUF)_g$(EXESUF): LDFLAGS += $(LDFLAGS-$(1))
 $(1)$(PROGSSUF)_g$(EXESUF): FF_EXTRALIBS += $(EXTRALIBS-$(1))
@@ -56,6 +56,7 @@ all: $(AVPROGS)
 fftools/ffprobe.o fftools/cmdutils.o: libavutil/ffversion.h | fftools
 OUTDIRS += fftools
 OUTDIRS += fftools/textformat
+OUTDIRS += fftools/resources
 
 ifdef AVPROGS
 install: install-progs install-data

--- a/fftools/Makefile
+++ b/fftools/Makefile
@@ -22,6 +22,7 @@ OBJS-ffmpeg +=                  \
     fftools/ffmpeg_opt.o        \
     fftools/ffmpeg_sched.o      \
     fftools/graph/graphprint.o        \
+    fftools/graph/filelauncher.o      \
     fftools/sync_queue.o        \
     fftools/thread_queue.o      \
     fftools/textformat/avtextformat.o \

--- a/fftools/ffmpeg.c
+++ b/fftools/ffmpeg.c
@@ -309,7 +309,7 @@ const AVIOInterruptCB int_cb = { decode_interrupt_cb, NULL };
 
 static void ffmpeg_cleanup(int ret)
 {
-    if (print_graphs || print_graphs_file)
+    if (print_graphs || print_graphs_file || show_graph)
         print_filtergraphs(filtergraphs, nb_filtergraphs, input_files, nb_input_files, output_files, nb_output_files);
 
     if (do_benchmark) {

--- a/fftools/ffmpeg.c
+++ b/fftools/ffmpeg.c
@@ -81,6 +81,7 @@
 #include "ffmpeg.h"
 #include "ffmpeg_sched.h"
 #include "ffmpeg_utils.h"
+#include "graph/graphprint.h"
 
 const char program_name[] = "ffmpeg";
 const int program_birth_year = 2000;
@@ -308,6 +309,9 @@ const AVIOInterruptCB int_cb = { decode_interrupt_cb, NULL };
 
 static void ffmpeg_cleanup(int ret)
 {
+    if (print_graphs || print_graphs_file)
+        print_filtergraphs(filtergraphs, nb_filtergraphs, input_files, nb_input_files, output_files, nb_output_files);
+
     if (do_benchmark) {
         int64_t maxrss = getmaxrss() / 1024;
         av_log(NULL, AV_LOG_INFO, "bench: maxrss=%"PRId64"KiB\n", maxrss);

--- a/fftools/ffmpeg.h
+++ b/fftools/ffmpeg.h
@@ -717,6 +717,9 @@ extern float max_error_rate;
 extern char *filter_nbthreads;
 extern int filter_complex_nbthreads;
 extern int vstats_version;
+extern int print_graphs;
+extern char *print_graphs_file;
+extern char *print_graphs_format;
 extern int auto_conversion_filters;
 
 extern const AVIOInterruptCB int_cb;

--- a/fftools/ffmpeg.h
+++ b/fftools/ffmpeg.h
@@ -721,6 +721,7 @@ extern int print_graphs;
 extern char *print_graphs_file;
 extern char *print_graphs_format;
 extern int auto_conversion_filters;
+extern int show_graph;
 
 extern const AVIOInterruptCB int_cb;
 

--- a/fftools/ffmpeg_filter.c
+++ b/fftools/ffmpeg_filter.c
@@ -2985,7 +2985,7 @@ read_frames:
 
 finish:
 
-    if (print_graphs || print_graphs_file)
+    if (print_graphs || print_graphs_file || show_graph)
         print_filtergraph(fg, fgt.graph);
 
     // EOF is normal termination

--- a/fftools/ffmpeg_filter.c
+++ b/fftools/ffmpeg_filter.c
@@ -22,6 +22,7 @@
 
 #include "ffmpeg.h"
 #include "ffmpeg_filter.h"
+#include "graph/graphprint.h"
 
 #include "libavfilter/avfilter.h"
 #include "libavfilter/buffersink.h"
@@ -2983,6 +2984,10 @@ read_frames:
     }
 
 finish:
+
+    if (print_graphs || print_graphs_file)
+        print_filtergraph(fg, fgt.graph);
+
     // EOF is normal termination
     if (ret == AVERROR_EOF)
         ret = 0;

--- a/fftools/ffmpeg_filter.c
+++ b/fftools/ffmpeg_filter.c
@@ -21,6 +21,7 @@
 #include <stdint.h>
 
 #include "ffmpeg.h"
+#include "ffmpeg_filter.h"
 
 #include "libavfilter/avfilter.h"
 #include "libavfilter/buffersink.h"
@@ -42,44 +43,6 @@
 // FIXME private header, used for mid_pred()
 #include "libavcodec/mathops.h"
 
-typedef struct FilterGraphPriv {
-    FilterGraph      fg;
-
-    // name used for logging
-    char             log_name[32];
-
-    int              is_simple;
-    // true when the filtergraph contains only meta filters
-    // that do not modify the frame data
-    int              is_meta;
-    // source filters are present in the graph
-    int              have_sources;
-    int              disable_conversions;
-
-    unsigned         nb_outputs_done;
-
-    const char      *graph_desc;
-
-    int              nb_threads;
-
-    // frame for temporarily holding output from the filtergraph
-    AVFrame         *frame;
-    // frame for sending output to the encoder
-    AVFrame         *frame_enc;
-
-    Scheduler       *sch;
-    unsigned         sch_idx;
-} FilterGraphPriv;
-
-static FilterGraphPriv *fgp_from_fg(FilterGraph *fg)
-{
-    return (FilterGraphPriv*)fg;
-}
-
-static const FilterGraphPriv *cfgp_from_cfg(const FilterGraph *fg)
-{
-    return (const FilterGraphPriv*)fg;
-}
 
 // data that is local to the filter thread and not visible outside of it
 typedef struct FilterGraphThread {
@@ -101,157 +64,6 @@ typedef struct FilterGraphThread {
     uint8_t         *eof_in;
     uint8_t         *eof_out;
 } FilterGraphThread;
-
-typedef struct InputFilterPriv {
-    InputFilter         ifilter;
-
-    InputFilterOptions  opts;
-
-    int                 index;
-
-    AVFilterContext    *filter;
-
-    // used to hold submitted input
-    AVFrame            *frame;
-
-    /* for filters that are not yet bound to an input stream,
-     * this stores the input linklabel, if any */
-    uint8_t            *linklabel;
-
-    // filter data type
-    enum AVMediaType    type;
-    // source data type: AVMEDIA_TYPE_SUBTITLE for sub2video,
-    // same as type otherwise
-    enum AVMediaType    type_src;
-
-    int                 eof;
-    int                 bound;
-    int                 drop_warned;
-    uint64_t            nb_dropped;
-
-    // parameters configured for this input
-    int                 format;
-
-    int                 width, height;
-    AVRational          sample_aspect_ratio;
-    enum AVColorSpace   color_space;
-    enum AVColorRange   color_range;
-
-    int                 sample_rate;
-    AVChannelLayout     ch_layout;
-
-    AVRational          time_base;
-
-    AVFrameSideData   **side_data;
-    int                 nb_side_data;
-
-    AVFifo             *frame_queue;
-
-    AVBufferRef        *hw_frames_ctx;
-
-    int                 displaymatrix_present;
-    int                 displaymatrix_applied;
-    int32_t             displaymatrix[9];
-
-    int                 downmixinfo_present;
-    AVDownmixInfo       downmixinfo;
-
-    struct {
-        AVFrame *frame;
-
-        int64_t last_pts;
-        int64_t end_pts;
-
-        /// marks if sub2video_update should force an initialization
-        unsigned int initialize;
-    } sub2video;
-} InputFilterPriv;
-
-static InputFilterPriv *ifp_from_ifilter(InputFilter *ifilter)
-{
-    return (InputFilterPriv*)ifilter;
-}
-
-typedef struct FPSConvContext {
-    AVFrame          *last_frame;
-    /* number of frames emitted by the video-encoding sync code */
-    int64_t           frame_number;
-    /* history of nb_frames_prev, i.e. the number of times the
-     * previous frame was duplicated by vsync code in recent
-     * do_video_out() calls */
-    int64_t           frames_prev_hist[3];
-
-    uint64_t          dup_warning;
-
-    int               last_dropped;
-    int               dropped_keyframe;
-
-    enum VideoSyncMethod vsync_method;
-
-    AVRational        framerate;
-    AVRational        framerate_max;
-    const AVRational *framerate_supported;
-    int               framerate_clip;
-} FPSConvContext;
-
-typedef struct OutputFilterPriv {
-    OutputFilter            ofilter;
-
-    int                     index;
-
-    void                   *log_parent;
-    char                    log_name[32];
-
-    char                   *name;
-
-    AVFilterContext        *filter;
-
-    /* desired output stream properties */
-    int                     format;
-    int                     width, height;
-    int                     sample_rate;
-    AVChannelLayout         ch_layout;
-    enum AVColorSpace       color_space;
-    enum AVColorRange       color_range;
-
-    AVFrameSideData       **side_data;
-    int                     nb_side_data;
-
-    // time base in which the output is sent to our downstream
-    // does not need to match the filtersink's timebase
-    AVRational              tb_out;
-    // at least one frame with the above timebase was sent
-    // to our downstream, so it cannot change anymore
-    int                     tb_out_locked;
-
-    AVRational              sample_aspect_ratio;
-
-    AVDictionary           *sws_opts;
-    AVDictionary           *swr_opts;
-
-    // those are only set if no format is specified and the encoder gives us multiple options
-    // They point directly to the relevant lists of the encoder.
-    const int              *formats;
-    const AVChannelLayout  *ch_layouts;
-    const int              *sample_rates;
-    const enum AVColorSpace *color_spaces;
-    const enum AVColorRange *color_ranges;
-
-    AVRational              enc_timebase;
-    int64_t                 trim_start_us;
-    int64_t                 trim_duration_us;
-    // offset for output timestamps, in AV_TIME_BASE_Q
-    int64_t                 ts_offset;
-    int64_t                 next_pts;
-    FPSConvContext          fps;
-
-    unsigned                flags;
-} OutputFilterPriv;
-
-static OutputFilterPriv *ofp_from_ofilter(OutputFilter *ofilter)
-{
-    return (OutputFilterPriv*)ofilter;
-}
 
 typedef struct FilterCommand {
     char *target;

--- a/fftools/ffmpeg_filter.h
+++ b/fftools/ffmpeg_filter.h
@@ -1,0 +1,234 @@
+/*
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef FFTOOLS_FFMPEG_FILTER_H
+#define FFTOOLS_FFMPEG_FILTER_H
+
+#include "ffmpeg.h"
+
+#include <stdint.h>
+
+#include "ffmpeg_sched.h"
+#include "sync_queue.h"
+
+#include "libavfilter/avfilter.h"
+
+#include "libavutil/avutil.h"
+#include "libavutil/dict.h"
+#include "libavutil/fifo.h"
+#include "libavutil/pixfmt.h"
+#include "libavutil/rational.h"
+#include "libavutil/bprint.h"
+#include "libavutil/channel_layout.h"
+#include "libavutil/downmix_info.h"
+
+typedef struct FilterGraphPriv {
+    FilterGraph      fg;
+
+    // name used for logging
+    char             log_name[32];
+
+    int              is_simple;
+    // true when the filtergraph contains only meta filters
+    // that do not modify the frame data
+    int              is_meta;
+    // source filters are present in the graph
+    int              have_sources;
+    int              disable_conversions;
+
+    unsigned         nb_outputs_done;
+
+    const char      *graph_desc;
+
+    int              nb_threads;
+
+    // frame for temporarily holding output from the filtergraph
+    AVFrame         *frame;
+    // frame for sending output to the encoder
+    AVFrame         *frame_enc;
+
+    Scheduler       *sch;
+    unsigned         sch_idx;
+
+    AVBPrint graph_print_buf;
+
+} FilterGraphPriv;
+
+static inline FilterGraphPriv *fgp_from_fg(FilterGraph *fg)
+{
+    return (FilterGraphPriv*)fg;
+}
+
+static inline const FilterGraphPriv *cfgp_from_cfg(const FilterGraph *fg)
+{
+    return (const FilterGraphPriv*)fg;
+}
+
+typedef struct InputFilterPriv {
+    InputFilter         ifilter;
+
+    InputFilterOptions  opts;
+
+    int                 index;
+
+    AVFilterContext    *filter;
+
+    // used to hold submitted input
+    AVFrame            *frame;
+
+    /* for filters that are not yet bound to an input stream,
+     * this stores the input linklabel, if any */
+    uint8_t            *linklabel;
+
+    // filter data type
+    enum AVMediaType    type;
+    // source data type: AVMEDIA_TYPE_SUBTITLE for sub2video,
+    // same as type otherwise
+    enum AVMediaType    type_src;
+
+    int                 eof;
+    int                 bound;
+    int                 drop_warned;
+    uint64_t            nb_dropped;
+
+    // parameters configured for this input
+    int                 format;
+
+    int                 width, height;
+    AVRational          sample_aspect_ratio;
+    enum AVColorSpace   color_space;
+    enum AVColorRange   color_range;
+
+    int                 sample_rate;
+    AVChannelLayout     ch_layout;
+
+    AVRational          time_base;
+
+    AVFrameSideData   **side_data;
+    int                 nb_side_data;
+
+    AVFifo             *frame_queue;
+
+    AVBufferRef        *hw_frames_ctx;
+
+    int                 displaymatrix_present;
+    int                 displaymatrix_applied;
+    int32_t             displaymatrix[9];
+
+    int                 downmixinfo_present;
+    AVDownmixInfo       downmixinfo;
+
+    struct {
+        AVFrame *frame;
+
+        int64_t last_pts;
+        int64_t end_pts;
+
+        /// marks if sub2video_update should force an initialization
+        unsigned int initialize;
+    } sub2video;
+} InputFilterPriv;
+
+static inline InputFilterPriv *ifp_from_ifilter(InputFilter *ifilter)
+{
+    return (InputFilterPriv*)ifilter;
+}
+
+typedef struct FPSConvContext {
+    AVFrame          *last_frame;
+    /* number of frames emitted by the video-encoding sync code */
+    int64_t           frame_number;
+    /* history of nb_frames_prev, i.e. the number of times the
+     * previous frame was duplicated by vsync code in recent
+     * do_video_out() calls */
+    int64_t           frames_prev_hist[3];
+
+    uint64_t          dup_warning;
+
+    int               last_dropped;
+    int               dropped_keyframe;
+
+    enum VideoSyncMethod vsync_method;
+
+    AVRational        framerate;
+    AVRational        framerate_max;
+    const AVRational *framerate_supported;
+    int               framerate_clip;
+} FPSConvContext;
+
+
+typedef struct OutputFilterPriv {
+    OutputFilter            ofilter;
+
+    int                     index;
+
+    void                   *log_parent;
+    char                    log_name[32];
+
+    char                   *name;
+
+    AVFilterContext        *filter;
+
+    /* desired output stream properties */
+    int                     format;
+    int                     width, height;
+    int                     sample_rate;
+    AVChannelLayout         ch_layout;
+    enum AVColorSpace       color_space;
+    enum AVColorRange       color_range;
+
+    AVFrameSideData       **side_data;
+    int                     nb_side_data;
+
+    // time base in which the output is sent to our downstream
+    // does not need to match the filtersink's timebase
+    AVRational              tb_out;
+    // at least one frame with the above timebase was sent
+    // to our downstream, so it cannot change anymore
+    int                     tb_out_locked;
+
+    AVRational              sample_aspect_ratio;
+
+    AVDictionary           *sws_opts;
+    AVDictionary           *swr_opts;
+
+    // those are only set if no format is specified and the encoder gives us multiple options
+    // They point directly to the relevant lists of the encoder.
+    const int              *formats;
+    const AVChannelLayout  *ch_layouts;
+    const int              *sample_rates;
+    const enum AVColorSpace *color_spaces;
+    const enum AVColorRange *color_ranges;
+
+    AVRational              enc_timebase;
+    int64_t                 trim_start_us;
+    int64_t                 trim_duration_us;
+    // offset for output timestamps, in AV_TIME_BASE_Q
+    int64_t                 ts_offset;
+    int64_t                 next_pts;
+    FPSConvContext          fps;
+
+    unsigned                flags;
+} OutputFilterPriv;
+
+static inline OutputFilterPriv *ofp_from_ofilter(OutputFilter *ofilter)
+{
+    return (OutputFilterPriv*)ofilter;
+}
+
+#endif /* FFTOOLS_FFMPEG_FILTER_H */

--- a/fftools/ffmpeg_mux.h
+++ b/fftools/ffmpeg_mux.h
@@ -123,7 +123,7 @@ typedef struct Muxer {
 
 int mux_check_init(void *arg);
 
-static MuxStream *ms_from_ost(OutputStream *ost)
+static inline MuxStream *ms_from_ost(OutputStream *ost)
 {
     return (MuxStream*)ost;
 }

--- a/fftools/ffmpeg_opt.c
+++ b/fftools/ffmpeg_opt.c
@@ -47,6 +47,7 @@
 #include "libavutil/opt.h"
 #include "libavutil/parseutils.h"
 #include "libavutil/stereo3d.h"
+#include "graph/graphprint.h"
 
 HWDevice *filter_hw_device;
 
@@ -75,6 +76,9 @@ float max_error_rate  = 2.0/3;
 char *filter_nbthreads;
 int filter_complex_nbthreads = 0;
 int vstats_version = 2;
+int print_graphs = 0;
+char *print_graphs_file = NULL;
+char *print_graphs_format = NULL;
 int auto_conversion_filters = 1;
 int64_t stats_period = 500000;
 
@@ -1735,6 +1739,15 @@ const OptionDef options[] = {
         { .func_arg = opt_filter_complex_script },
         "deprecated, use -/filter_complex instead", "filename" },
 #endif
+    { "print_graphs",   OPT_TYPE_BOOL, 0,
+        { &print_graphs },
+        "print execution graph data to stderr" },
+    { "print_graphs_file", OPT_TYPE_STRING, 0,
+        { &print_graphs_file },
+        "write execution graph data to the specified file", "filename" },
+    { "print_graphs_format", OPT_TYPE_STRING, 0,
+        { &print_graphs_format },
+      "set the output printing format (available formats are: default, compact, csv, flat, ini, json, xml, mermaid, mermaidhtml)", "format" },
     { "auto_conversion_filters", OPT_TYPE_BOOL, OPT_EXPERT,
         { &auto_conversion_filters },
         "enable automatic conversion filters globally" },

--- a/fftools/ffmpeg_opt.c
+++ b/fftools/ffmpeg_opt.c
@@ -79,6 +79,7 @@ int vstats_version = 2;
 int print_graphs = 0;
 char *print_graphs_file = NULL;
 char *print_graphs_format = NULL;
+int show_graph = 0;
 int auto_conversion_filters = 1;
 int64_t stats_period = 500000;
 
@@ -1748,6 +1749,9 @@ const OptionDef options[] = {
     { "print_graphs_format", OPT_TYPE_STRING, 0,
         { &print_graphs_format },
       "set the output printing format (available formats are: default, compact, csv, flat, ini, json, xml, mermaid, mermaidhtml)", "format" },
+    { "sg",   OPT_TYPE_BOOL, 0,
+        { &show_graph },
+        "create execution graph as temporary html file and try to launch it in the default browser" },
     { "auto_conversion_filters", OPT_TYPE_BOOL, OPT_EXPERT,
         { &auto_conversion_filters },
         "enable automatic conversion filters globally" },

--- a/fftools/ffprobe.c
+++ b/fftools/ffprobe.c
@@ -3167,10 +3167,15 @@ int main(int argc, char **argv)
     if (ret < 0)
         goto end;
 
-    if ((ret = avtext_context_open(&tctx, f, wctx, f_args,
-                           sections, FF_ARRAY_ELEMS(sections), show_value_unit,
-                            use_value_prefix, use_byte_value_binary_prefix, use_value_sexagesimal_format,
-                            show_optional_fields, show_data_hash)) >= 0) {
+    AVTextFormatOptions tf_options = {
+        .show_optional_fields = show_optional_fields,
+        .show_value_unit = show_value_unit,
+        .use_value_prefix = use_value_prefix,
+        .use_byte_value_binary_prefix = use_byte_value_binary_prefix,
+        .use_value_sexagesimal_format = use_value_sexagesimal_format,
+    };
+
+    if ((ret = avtext_context_open(&tctx, f, wctx, f_args, sections, FF_ARRAY_ELEMS(sections), tf_options, show_data_hash)) >= 0) {
         if (f == &avtextformatter_xml)
             tctx->string_validation_utf8_flags |= AV_UTF8_FLAG_EXCLUDE_XML_INVALID_CONTROL_CODES;
 

--- a/fftools/ffprobe.c
+++ b/fftools/ffprobe.c
@@ -420,7 +420,7 @@ static void log_callback(void *ptr, int level, const char *fmt, va_list vl)
     avtext_print_string(tfc, k, pbuf.str, 0);     \
 } while (0)
 
-#define print_int(k, v)         avtext_print_integer(tfc, k, v)
+#define print_int(k, v)         avtext_print_integer(tfc, k, v, 0)
 #define print_q(k, v, s)        avtext_print_rational(tfc, k, v, s)
 #define print_str(k, v)         avtext_print_string(tfc, k, v, 0)
 #define print_str_opt(k, v)     avtext_print_string(tfc, k, v, AV_TEXTFORMAT_PRINT_STRING_OPTIONAL)

--- a/fftools/graph/filelauncher.c
+++ b/fftools/graph/filelauncher.c
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2025 - softworkz
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(_WIN32)
+#  include <windows.h>
+#  include <shellapi.h>
+#else
+#  include <sys/time.h>
+#  include <time.h>
+#endif
+#include "graphprint.h"
+
+int ff_open_html_in_browser(const char *html_path)
+{
+    if (!html_path || !*html_path)
+        return -1;
+
+#if defined(_WIN32)
+
+    // --- Windows ---------------------------------
+    {
+        HINSTANCE rc = ShellExecuteA(NULL, "open", html_path, NULL, NULL, SW_SHOWNORMAL);
+        if ((UINT_PTR)rc <= 32) {
+            // Fallback: system("start ...")
+            char cmd[1024];
+            _snprintf_s(cmd, sizeof(cmd), _TRUNCATE, "start \"\" \"%s\"", html_path);
+            if (system(cmd) != 0)
+                return -1;
+        }
+        return 0;
+    }
+
+#elif defined(__APPLE__)
+
+    // --- macOS -----------------------------------
+    {
+        // "open" is the macOS command to open a file/URL with the default application
+        char cmd[1024];
+        snprintf(cmd, sizeof(cmd), "open '%s' 1>/dev/null 2>&1 &", html_path);
+        if (system(cmd) != 0)
+            return -1;
+        return 0;
+    }
+
+#else
+
+    // --- Linux / Unix-like -----------------------
+    // We'll try xdg-open, then gnome-open, then kfmclient
+    {
+        // Helper macro to try one browser command
+        // Returns 0 on success, -1 on failure
+        #define TRY_CMD(prog) do {                                   \
+            char buf[1024];                                          \
+            snprintf(buf, sizeof(buf), "%s '%s' 1>/dev/null 2>&1 &", \
+                     (prog), html_path);                              \
+            int ret = system(buf);                                    \
+            /* On Unix: system() returns -1 if the shell can't run. */\
+            /* Otherwise, check exit code in lower 8 bits.           */\
+            if (ret != -1 && WIFEXITED(ret) && WEXITSTATUS(ret) == 0) \
+                return 0;                                             \
+        } while (0)
+
+        TRY_CMD("xdg-open");
+        TRY_CMD("gnome-open");
+        TRY_CMD("kfmclient exec");
+
+        fprintf(stderr, "Could not open '%s' in a browser.\n", html_path);
+        return -1;
+    }
+
+#endif
+}
+
+
+int ff_get_temp_dir(char *buf, size_t size)
+{
+#if defined(_WIN32)
+
+    // --- Windows ------------------------------------
+    {
+        // GetTempPathA returns length of the string (including trailing backslash).
+        // If the return value is greater than buffer size, it's an error.
+        DWORD len = GetTempPathA((DWORD)size, buf);
+        if (len == 0 || len > size) {
+            // Could not retrieve or buffer is too small
+            return -1;
+        }
+        return 0;
+    }
+
+#else
+
+    // --- macOS / Linux / Unix -----------------------
+    // Follow typical POSIX convention: check common env variables
+    // and fallback to /tmp if not found.
+    {
+        const char *tmp = getenv("TMPDIR");
+        if (!tmp || !*tmp) tmp = getenv("TMP");
+        if (!tmp || !*tmp) tmp = getenv("TEMP");
+        if (!tmp || !*tmp) tmp = "/tmp";
+
+        // Copy into buf, ensure there's a trailing slash
+        size_t len = strlen(tmp);
+        if (len + 2 > size) {
+            // Need up to len + 1 for slash + 1 for null terminator
+            return -1;
+        }
+
+        strcpy(buf, tmp);
+        // Append slash if necessary
+        if (buf[len - 1] != '/' && buf[len - 1] != '\\') {
+#if defined(__APPLE__)
+            // On macOS/Unix, use forward slash
+            buf[len] = '/';
+            buf[len + 1] = '\0';
+#else
+            // Technically on Unix it's always '/', but here's how you'd do if needed:
+            buf[len] = '/';
+            buf[len + 1] = '\0';
+#endif
+        }
+        return 0;
+    }
+
+#endif
+}
+
+int ff_make_timestamped_html_name(char *buf, size_t size)
+{
+#if defined(_WIN32)
+
+    /*----------- Windows version -----------*/
+    SYSTEMTIME st;
+    GetLocalTime(&st);
+    /*
+      st.wYear, st.wMonth, st.wDay,
+      st.wHour, st.wMinute, st.wSecond, st.wMilliseconds
+    */
+    int written = _snprintf_s(buf, size, _TRUNCATE,
+                              "ffmpeg_graph_%04d-%02d-%02d_%02d-%02d-%02d_%03d.html",
+                              st.wYear,
+                              st.wMonth,
+                              st.wDay,
+                              st.wHour,
+                              st.wMinute,
+                              st.wSecond,
+                              st.wMilliseconds);
+    if (written < 0)
+        return -1; /* Could not write into buffer */
+    return 0;
+
+#else
+
+    /*----------- macOS / Linux / Unix version -----------*/
+    struct timeval tv;
+    if (gettimeofday(&tv, NULL) != 0) {
+        return -1; /* gettimeofday failed */
+    }
+
+    struct tm local_tm;
+    localtime_r(&tv.tv_sec, &local_tm);
+
+    int ms = (int)(tv.tv_usec / 1000); /* convert microseconds to milliseconds */
+
+    /* 
+       local_tm.tm_year is years since 1900,
+       local_tm.tm_mon  is 0-based (0=Jan, 11=Dec) 
+    */
+    int written = snprintf(buf, size,
+                           "ffmpeg_graph_%04d-%02d-%02d_%02d-%02d-%02d_%03d.html",
+                           local_tm.tm_year + 1900,
+                           local_tm.tm_mon + 1,
+                           local_tm.tm_mday,
+                           local_tm.tm_hour,
+                           local_tm.tm_min,
+                           local_tm.tm_sec,
+                           ms);
+    if (written < 0 || (size_t)written >= size) {
+        return -1; /* Buffer too small or formatting error */
+    }
+    return 0;
+
+#endif
+}

--- a/fftools/graph/graphprint.c
+++ b/fftools/graph/graphprint.c
@@ -879,6 +879,11 @@ static int init_graphprint(GraphPrintContext **pgpc, AVBPrint *target_buf)
 
     av_bprint_init(target_buf, 0, AV_BPRINT_SIZE_UNLIMITED);
 
+    if (show_graph) {
+        if (!print_graphs_format || strcmp(print_graphs_format, "mermaidhtml") != 0)
+            print_graphs_format = av_strdup("mermaidhtml");
+    }
+
     if (!print_graphs_format)
         print_graphs_format = av_strdup("json");
     if (!print_graphs_format) {
@@ -1103,5 +1108,46 @@ cleanup:
 
 int print_filtergraphs(FilterGraph **graphs, int nb_graphs, InputFile **ifiles, int nb_ifiles, OutputFile **ofiles, int nb_ofiles)
 {
-    return print_filtergraphs_priv(graphs, nb_graphs, ifiles, nb_ifiles, ofiles, nb_ofiles);
+    int ret;
+
+    if (show_graph) {
+        char buf[2048];
+        AVBPrint bp;
+
+        av_bprint_init(&bp, 0, AV_BPRINT_SIZE_UNLIMITED);
+
+        print_graphs = 0;
+
+        ret = ff_get_temp_dir(buf, sizeof(buf));
+        if (ret) {
+            av_log(NULL, AV_LOG_ERROR, "Error getting temp directory path for graph output file\n");
+            return ret;
+        }
+
+        av_bprint_append_data(&bp, buf, strlen(buf));
+
+        ret = ff_make_timestamped_html_name(buf, sizeof(buf));
+        if (ret) {
+            av_log(NULL, AV_LOG_ERROR, "Error creating temp file name for graph output file\n");
+            return ret;
+        }
+
+        av_bprint_append_data(&bp, buf, strlen(buf));
+
+        av_bprint_finalize(&bp, &print_graphs_file);
+    }
+
+    ret = print_filtergraphs_priv(graphs, nb_graphs, ifiles, nb_ifiles, ofiles, nb_ofiles);
+
+    if (!ret && show_graph) {
+        av_log(NULL, AV_LOG_INFO, "Execution graph saved as: %s\n", print_graphs_file);
+        av_log(NULL, AV_LOG_INFO, "Trying to launch graph in browser...\n");
+
+        ret = ff_open_html_in_browser(print_graphs_file);
+        if (ret) {
+            av_log(NULL, AV_LOG_ERROR, "Browser could not be launched for execution graph display\nPlease open manually: %s\n", print_graphs_file);
+        }
+    }
+
+    return ret;
 }

--- a/fftools/graph/graphprint.c
+++ b/fftools/graph/graphprint.c
@@ -1,0 +1,1107 @@
+/*
+ * Copyright (c) 2018-2025 - softworkz
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file
+ * output writers for filtergraph details
+ */
+
+#include <string.h>
+#include <stdatomic.h>
+
+#include "graphprint.h"
+
+#include "fftools/ffmpeg_filter.h"
+#include "fftools/ffmpeg_mux.h"
+
+#include "libavutil/avassert.h"
+#include "libavutil/avstring.h"
+#include "libavutil/pixdesc.h"
+#include "libavutil/dict.h"
+#include "libavutil/common.h"
+#include "libavfilter/avfilter.h"
+#include "libavutil/buffer.h"
+#include "libavutil/hwcontext.h"
+#include "fftools/textformat/avtextformat.h"
+#include "fftools/textformat/tf_mermaid.h"
+#include "fftools/resources/resman.h"
+
+typedef enum {
+    SECTION_ID_ROOT,
+    SECTION_ID_FILTERGRAPHS,
+    SECTION_ID_FILTERGRAPH,
+    SECTION_ID_GRAPH_INPUTS,
+    SECTION_ID_GRAPH_INPUT,
+    SECTION_ID_GRAPH_OUTPUTS,
+    SECTION_ID_GRAPH_OUTPUT,
+    SECTION_ID_FILTERS,
+    SECTION_ID_FILTER,
+    SECTION_ID_FILTER_INPUTS,
+    SECTION_ID_FILTER_INPUT,
+    SECTION_ID_FILTER_OUTPUTS,
+    SECTION_ID_FILTER_OUTPUT,
+    SECTION_ID_HWFRAMESCONTEXT,
+    SECTION_ID_INPUTFILES,
+    SECTION_ID_INPUTFILE,
+    SECTION_ID_INPUTSTREAMS,
+    SECTION_ID_INPUTSTREAM,
+    SECTION_ID_OUTPUTFILES,
+    SECTION_ID_OUTPUTFILE,
+    SECTION_ID_OUTPUTSTREAMS,
+    SECTION_ID_OUTPUTSTREAM,
+    SECTION_ID_STREAMLINKS,
+    SECTION_ID_STREAMLINK,
+    SECTION_ID_DECODERS,
+    SECTION_ID_DECODER,
+    SECTION_ID_ENCODERS,
+    SECTION_ID_ENCODER,
+} SectionID;
+
+static struct AVTextFormatSection sections[] = {
+    [SECTION_ID_ROOT]            = { SECTION_ID_ROOT, "root", AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER, { SECTION_ID_FILTERGRAPHS, SECTION_ID_INPUTFILES, SECTION_ID_OUTPUTFILES, SECTION_ID_DECODERS, SECTION_ID_ENCODERS, SECTION_ID_STREAMLINKS, -1 } },
+
+    [SECTION_ID_FILTERGRAPHS]    = { SECTION_ID_FILTERGRAPHS, "graphs", AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_FILTERGRAPH, -1 } },
+    [SECTION_ID_FILTERGRAPH]     = { SECTION_ID_FILTERGRAPH, "graph", AV_TEXTFORMAT_SECTION_FLAG_HAS_VARIABLE_FIELDS, { SECTION_ID_GRAPH_INPUTS, SECTION_ID_GRAPH_OUTPUTS, SECTION_ID_FILTERS, -1 }, .element_name = "graph_info" },
+
+    [SECTION_ID_GRAPH_INPUTS]    = { SECTION_ID_GRAPH_INPUTS, "graph_inputs", AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_GRAPH_INPUT, -1 }, .id_key = "id" },
+    [SECTION_ID_GRAPH_INPUT]     = { SECTION_ID_GRAPH_INPUT, "graph_input", 0, { -1 }, .id_key = "filter_id" },
+
+    [SECTION_ID_GRAPH_OUTPUTS]   = { SECTION_ID_GRAPH_OUTPUTS, "graph_outputs", AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_GRAPH_OUTPUT, -1 }, .id_key = "id" },
+    [SECTION_ID_GRAPH_OUTPUT]    = { SECTION_ID_GRAPH_OUTPUT, "graph_output", 0, { -1 }, .id_key = "filter_id" },
+
+    [SECTION_ID_FILTERS]         = { SECTION_ID_FILTERS, "filters", AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY | AV_TEXTFORMAT_SECTION_FLAG_IS_SUBGRAPH, { SECTION_ID_FILTER, -1 }, .id_key = "graph_id" },
+    [SECTION_ID_FILTER]          = { SECTION_ID_FILTER, "filter", AV_TEXTFORMAT_SECTION_FLAG_IS_SHAPE | AV_TEXTFORMAT_SECTION_PRINT_TAGS, { SECTION_ID_FILTER_INPUTS, SECTION_ID_FILTER_OUTPUTS, -1 }, .id_key = "filter_id" },
+
+    [SECTION_ID_FILTER_INPUTS]   = { SECTION_ID_FILTER_INPUTS, "filter_inputs", AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_FILTER_INPUT, -1 } },
+    [SECTION_ID_FILTER_INPUT]    = { SECTION_ID_FILTER_INPUT, "filter_input", AV_TEXTFORMAT_SECTION_FLAG_HAS_LINKS, { SECTION_ID_HWFRAMESCONTEXT, -1 }, .id_key = "filter_id", .src_id_key = "source_filter_id", .dest_id_key = "filter_id" },
+
+    [SECTION_ID_FILTER_OUTPUTS]  = { SECTION_ID_FILTER_OUTPUTS, "filter_outputs", AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_FILTER_OUTPUT, -1 } },
+    [SECTION_ID_FILTER_OUTPUT]   = { SECTION_ID_FILTER_OUTPUT, "filter_output", AV_TEXTFORMAT_SECTION_FLAG_HAS_LINKS, { SECTION_ID_HWFRAMESCONTEXT, -1 }, .id_key = "filter_id", .src_id_key = "filter_id", .dest_id_key = "dest_filter_id" },
+
+    [SECTION_ID_HWFRAMESCONTEXT] = { SECTION_ID_HWFRAMESCONTEXT, "hw_frames_context",  0, { -1 }, },
+
+    [SECTION_ID_INPUTFILES]      = { SECTION_ID_INPUTFILES, "inputfiles", AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY | AV_TEXTFORMAT_SECTION_FLAG_IS_SUBGRAPH, { SECTION_ID_INPUTFILE, -1 }, .id_key = "id" },
+    [SECTION_ID_INPUTFILE]       = { SECTION_ID_INPUTFILE, "inputfile", AV_TEXTFORMAT_SECTION_FLAG_IS_SUBGRAPH, { SECTION_ID_INPUTSTREAMS, -1 }, .id_key = "id" },
+
+    [SECTION_ID_INPUTSTREAMS]    = { SECTION_ID_INPUTSTREAMS, "inputstreams", AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY | AV_TEXTFORMAT_SECTION_FLAG_IS_SUBGRAPH, { SECTION_ID_INPUTSTREAM, -1 }, .id_key = "id" },
+    [SECTION_ID_INPUTSTREAM]     = { SECTION_ID_INPUTSTREAM, "inputstream", AV_TEXTFORMAT_SECTION_FLAG_IS_SHAPE | AV_TEXTFORMAT_SECTION_PRINT_TAGS, { -1 }, .id_key = "id" },
+
+    [SECTION_ID_OUTPUTFILES]     = { SECTION_ID_OUTPUTFILES, "outputfiles", AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY | AV_TEXTFORMAT_SECTION_FLAG_IS_SUBGRAPH, { SECTION_ID_OUTPUTFILE, -1 }, .id_key = "id" },
+    [SECTION_ID_OUTPUTFILE]      = { SECTION_ID_OUTPUTFILE, "outputfile", AV_TEXTFORMAT_SECTION_FLAG_IS_SUBGRAPH, { SECTION_ID_OUTPUTSTREAMS, -1 }, .id_key = "id" },
+
+    [SECTION_ID_OUTPUTSTREAMS]   = { SECTION_ID_OUTPUTSTREAMS, "outputstreams", AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY | AV_TEXTFORMAT_SECTION_FLAG_IS_SUBGRAPH, { SECTION_ID_OUTPUTSTREAM, -1 }, .id_key = "id" },
+    [SECTION_ID_OUTPUTSTREAM]    = { SECTION_ID_OUTPUTSTREAM, "outputstream", AV_TEXTFORMAT_SECTION_FLAG_IS_SHAPE | AV_TEXTFORMAT_SECTION_PRINT_TAGS, { -1 }, .id_key = "id", },
+
+    [SECTION_ID_STREAMLINKS]     = { SECTION_ID_STREAMLINKS, "streamlinks", AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_STREAMLINK, -1 } },
+    [SECTION_ID_STREAMLINK]      = { SECTION_ID_STREAMLINK, "streamlink", AV_TEXTFORMAT_SECTION_FLAG_HAS_LINKS, { -1 }, .src_id_key = "source_stream_id", .dest_id_key = "dest_stream_id" },
+
+    [SECTION_ID_DECODERS]        = { SECTION_ID_DECODERS, "decoders", AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY | AV_TEXTFORMAT_SECTION_FLAG_IS_SUBGRAPH, { SECTION_ID_DECODER, -1 } },
+    [SECTION_ID_DECODER]         = { SECTION_ID_DECODER, "decoder", AV_TEXTFORMAT_SECTION_FLAG_IS_SHAPE | AV_TEXTFORMAT_SECTION_PRINT_TAGS | AV_TEXTFORMAT_SECTION_FLAG_HAS_LINKS, { -1 }, .id_key = "id", .src_id_key = "source_id", .dest_id_key = "id" },
+
+    [SECTION_ID_ENCODERS]        = { SECTION_ID_ENCODERS, "encoders", AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY | AV_TEXTFORMAT_SECTION_FLAG_IS_SUBGRAPH, { SECTION_ID_ENCODER, -1 } },
+    [SECTION_ID_ENCODER]         = { SECTION_ID_ENCODER, "encoder", AV_TEXTFORMAT_SECTION_FLAG_IS_SHAPE | AV_TEXTFORMAT_SECTION_PRINT_TAGS | AV_TEXTFORMAT_SECTION_FLAG_HAS_LINKS, { -1 }, .id_key = "id", .src_id_key = "id", .dest_id_key = "dest_id" },
+};
+
+typedef struct GraphPrintContext {
+    AVTextFormatContext *tfc;
+    AVTextWriterContext *wctx;
+    AVDiagramConfig diagram_config;
+
+    int id_prefix_num;
+    int is_diagram;
+    int opt_flags;
+    int skip_buffer_filters;
+    AVBPrint pbuf;
+
+} GraphPrintContext;
+
+/* Text Format API Shortcuts */
+#define print_id(k, v)          print_sanizied_id(gpc, k, v, 0)
+#define print_id_noprefix(k, v) print_sanizied_id(gpc, k, v, 1)
+#define print_int(k, v)         avtext_print_integer(tfc, k, v, 0)
+#define print_int_opt(k, v)     avtext_print_integer(tfc, k, v, gpc->opt_flags)
+#define print_q(k, v, s)        avtext_print_rational(tfc, k, v, s)
+#define print_str(k, v)         avtext_print_string(tfc, k, v, 0)
+#define print_str_opt(k, v)     avtext_print_string(tfc, k, v, gpc->opt_flags)
+#define print_val(k, v, u)      avtext_print_unit_int(tfc, k, v, u)
+
+#define print_fmt(k, f, ...) do {              \
+    av_bprint_clear(&gpc->pbuf);                    \
+    av_bprintf(&gpc->pbuf, f, __VA_ARGS__);         \
+    avtext_print_string(tfc, k, gpc->pbuf.str, 0);    \
+} while (0)
+
+#define print_fmt_opt(k, f, ...) do {              \
+    av_bprint_clear(&gpc->pbuf);                    \
+    av_bprintf(&gpc->pbuf, f, __VA_ARGS__);         \
+    avtext_print_string(tfc, k, gpc->pbuf.str, gpc->opt_flags);    \
+} while (0)
+
+
+static atomic_int prefix_num = 0;
+
+static inline char *upcase_string(char *dst, size_t dst_size, const char *src)
+{
+    unsigned i;
+    for (i = 0; src[i] && i < dst_size - 1; i++)
+        dst[i]      = (char)av_toupper(src[i]);
+    dst[i] = 0;
+    return dst;
+}
+
+static char *get_extension(const char *url)
+{
+    const char *dot = NULL;
+    const char *sep = NULL;
+    const char *end;
+
+    if (!url)
+        return NULL;
+
+    /* Stop at the first query ('?') or fragment ('#') delimiter so they
+     * are not considered part of the path. */
+    end = strpbrk(url, "?#");
+    if (!end)
+        end = url + strlen(url);
+
+    /* Scan the path component only. */
+    for (const char *p = url; p < end; p++) {
+        if (*p == '.')
+            dot = p;
+        else if (*p == '/' || *p == '\\')
+            sep = p;
+    }
+
+    /* Validate that we have a proper extension. */
+    if (dot && dot != url && (!sep || dot > sep + 1) && (dot + 1) < end) {
+        /* Use FFmpeg helper to duplicate the substring. */
+        return av_strndup(dot + 1, end - (dot + 1));
+    }
+
+    return NULL;
+}
+
+static void print_hwdevicecontext(const GraphPrintContext *gpc, const AVHWDeviceContext *hw_device_context)
+{
+    AVTextFormatContext *tfc = gpc->tfc;
+
+    if (!hw_device_context)
+        return;
+
+    print_int_opt("has_hw_device_context", 1);
+    print_str_opt("hw_device_type", av_hwdevice_get_type_name(hw_device_context->type));
+}
+
+static void print_hwframescontext(const GraphPrintContext *gpc, const AVHWFramesContext *hw_frames_context)
+{
+    AVTextFormatContext *tfc = gpc->tfc;
+    const AVPixFmtDescriptor *pix_desc_hw;
+    const AVPixFmtDescriptor *pix_desc_sw;
+
+    if (!hw_frames_context || !hw_frames_context->device_ctx)
+        return;
+
+    avtext_print_section_header(tfc, NULL, SECTION_ID_HWFRAMESCONTEXT);
+
+    print_int_opt("has_hw_frames_context", 1);
+    print_str("hw_device_type", av_hwdevice_get_type_name(hw_frames_context->device_ctx->type));
+
+    pix_desc_hw = av_pix_fmt_desc_get(hw_frames_context->format);
+    if (pix_desc_hw) {
+        print_str("hw_pixel_format", pix_desc_hw->name);
+        if (pix_desc_hw->alias)
+            print_str_opt("hw_pixel_format_alias", pix_desc_hw->alias);
+    }
+
+    pix_desc_sw = av_pix_fmt_desc_get(hw_frames_context->sw_format);
+    if (pix_desc_sw) {
+        print_str("sw_pixel_format", pix_desc_sw->name);
+        if (pix_desc_sw->alias)
+            print_str_opt("sw_pixel_format_alias", pix_desc_sw->alias);
+    }
+
+    print_int_opt("width", hw_frames_context->width);
+    print_int_opt("height", hw_frames_context->height);
+    print_int_opt("initial_pool_size", hw_frames_context->initial_pool_size);
+
+    avtext_print_section_footer(tfc); // SECTION_ID_HWFRAMESCONTEXT
+}
+
+static void print_link(GraphPrintContext *gpc, AVFilterLink *link)
+{
+    AVTextFormatContext *tfc = gpc->tfc;
+    AVBufferRef *hw_frames_ctx;
+    char layout_string[64];
+
+    if (!link)
+        return;
+
+    hw_frames_ctx = avfilter_link_get_hw_frames_ctx(link);
+
+    print_str_opt("media_type", av_get_media_type_string(link->type));
+
+    switch (link->type) {
+    case AVMEDIA_TYPE_VIDEO:
+
+        if (hw_frames_ctx && hw_frames_ctx->data) {
+            AVHWFramesContext *      hwfctx      = (AVHWFramesContext *)hw_frames_ctx->data;
+            const AVPixFmtDescriptor *pix_desc_hw = av_pix_fmt_desc_get(hwfctx->format);
+            const AVPixFmtDescriptor *pix_desc_sw = av_pix_fmt_desc_get(hwfctx->sw_format);
+            if (pix_desc_hw && pix_desc_sw)
+                print_fmt("format", "%s | %s", pix_desc_hw->name, pix_desc_sw->name);
+        } else {
+            print_str("format", av_x_if_null(av_get_pix_fmt_name(link->format), "?"));
+        }
+
+        if (link->w && link->h) {
+            if (tfc->show_value_unit) {
+                print_fmt("size", "%dx%d", link->w, link->h);
+            } else {
+                print_int("width", link->w);
+                print_int("height", link->h);
+            }
+        }
+
+        print_q("sar", link->sample_aspect_ratio, ':');
+
+        if (link->color_range != AVCOL_RANGE_UNSPECIFIED)
+            print_str_opt("color_range", av_color_range_name(link->color_range));
+
+        if (link->colorspace != AVCOL_SPC_UNSPECIFIED)
+            print_str("color_space", av_color_space_name(link->colorspace));
+        break;
+
+    case AVMEDIA_TYPE_SUBTITLE:
+        ////print_str("format", av_x_if_null(av_get_subtitle_fmt_name(link->format), "?"));
+
+        if (link->w && link->h) {
+            if (tfc->show_value_unit) {
+                print_fmt("size", "%dx%d", link->w, link->h);
+            } else {
+                print_int("width", link->w);
+                print_int("height", link->h);
+            }
+        }
+
+        break;
+
+    case AVMEDIA_TYPE_AUDIO:
+        av_channel_layout_describe(&link->ch_layout, layout_string, sizeof(layout_string));
+        print_str("channel_layout", layout_string);
+        print_val("channels", link->ch_layout.nb_channels, "ch");
+        if (tfc->show_value_unit)
+            print_fmt("sample_rate", "%d.1 kHz", link->sample_rate / 1000);
+        else
+            print_val("sample_rate", link->sample_rate, "Hz");
+
+        break;
+    }
+
+    print_fmt_opt("sample_rate", "%d/%d", link->time_base.num, link->time_base.den);
+
+    if (hw_frames_ctx && hw_frames_ctx->data)
+        print_hwframescontext(gpc, (AVHWFramesContext *)hw_frames_ctx->data);
+}
+
+static char sanitize_char(const char c)
+{
+    if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'))
+        return c;
+    return '_';
+}
+
+static void print_sanizied_id(const GraphPrintContext *gpc, const char *key, const char *id_str, int skip_prefix)
+{
+    AVTextFormatContext *tfc = gpc->tfc;
+    AVBPrint buf;
+
+    if (!key || !id_str)
+        return;
+
+    av_bprint_init(&buf, 0, AV_BPRINT_SIZE_UNLIMITED);
+
+    if (!skip_prefix)
+        av_bprintf(&buf, "G%d_", gpc->id_prefix_num);
+
+    // sanizize section id
+    for (const char *p = id_str; *p; p++)
+        av_bprint_chars(&buf, sanitize_char(*p), 1);
+
+    print_str(key, buf.str);
+
+    av_bprint_finalize(&buf, NULL);
+}
+
+static void print_section_header_id(const GraphPrintContext *gpc, int section_id, const char *id_str, int skip_prefix)
+{
+    AVTextFormatContext *tfc = gpc->tfc;
+    AVTextFormatSectionContext sec_ctx = { 0 };
+    AVBPrint buf;
+
+    if (!id_str)
+        return;
+
+    av_bprint_init(&buf, 0, AV_BPRINT_SIZE_UNLIMITED);
+
+    if (!skip_prefix)
+        av_bprintf(&buf, "G%d_", gpc->id_prefix_num);
+
+    // sanizize section id
+    for (const char *p = id_str; *p; p++)
+        av_bprint_chars(&buf, sanitize_char(*p), 1);
+
+    sec_ctx.context_id = buf.str;
+
+    avtext_print_section_header(tfc, &sec_ctx, section_id);
+
+    av_bprint_finalize(&buf, NULL);
+}
+
+static const char *get_filterpad_name(const AVFilterPad *pad)
+{
+    return pad ? avfilter_pad_get_name(pad, 0) : "pad";
+}
+
+static void print_filter(GraphPrintContext *gpc, const AVFilterContext *filter, AVDictionary *input_map, AVDictionary *output_map)
+{
+    AVTextFormatContext *tfc = gpc->tfc;
+    AVTextFormatSectionContext sec_ctx = { 0 };
+
+    print_section_header_id(gpc, SECTION_ID_FILTER, filter->name, 0);
+
+    ////print_id("filter_id", filter->name);
+
+    if (filter->filter) {
+        print_str("filter_name", filter->filter->name);
+        print_str_opt("description", filter->filter->description);
+        print_int_opt("nb_inputs", filter->nb_inputs);
+        print_int_opt("nb_outputs", filter->nb_outputs);
+    }
+
+    if (filter->hw_device_ctx) {
+        AVHWDeviceContext *device_context = (AVHWDeviceContext *)filter->hw_device_ctx->data;
+        print_hwdevicecontext(gpc, device_context);
+        if (filter->extra_hw_frames > 0)
+            print_int("extra_hw_frames", filter->extra_hw_frames);
+    }
+
+    avtext_print_section_header(tfc, NULL, SECTION_ID_FILTER_INPUTS);
+
+    for (unsigned i = 0; i < filter->nb_inputs; i++) {
+        AVDictionaryEntry *dic_entry;
+        AVFilterLink *link = filter->inputs[i];
+
+        sec_ctx.context_type = av_get_media_type_string(link->type);
+        avtext_print_section_header(tfc, &sec_ctx, SECTION_ID_FILTER_INPUT);
+        sec_ctx.context_type = NULL;
+
+        print_int_opt("input_index", i);
+        print_str_opt("pad_name", get_filterpad_name(link->dstpad));;
+
+        dic_entry = av_dict_get(input_map, link->src->name, NULL, 0);
+        if (dic_entry) {
+            char buf[256];
+            (void)snprintf(buf, sizeof(buf), "in_%s", dic_entry->value);
+            print_id_noprefix("source_filter_id", buf);
+        } else {
+            print_id("source_filter_id", link->src->name);
+        }
+
+        print_str_opt("source_pad_name", get_filterpad_name(link->srcpad));
+        print_id("filter_id", filter->name);
+
+        print_link(gpc, link);
+
+        avtext_print_section_footer(tfc); // SECTION_ID_FILTER_INPUT
+    }
+
+    avtext_print_section_footer(tfc); // SECTION_ID_FILTER_INPUTS
+
+    avtext_print_section_header(tfc, NULL, SECTION_ID_FILTER_OUTPUTS);
+
+    for (unsigned i = 0; i < filter->nb_outputs; i++) {
+        AVDictionaryEntry *dic_entry;
+        AVFilterLink *link = filter->outputs[i];
+        char buf[256];
+
+        sec_ctx.context_type = av_get_media_type_string(link->type);
+        avtext_print_section_header(tfc, &sec_ctx, SECTION_ID_FILTER_OUTPUT);
+        sec_ctx.context_type = NULL;
+
+        dic_entry = av_dict_get(output_map, link->dst->name, NULL, 0);
+        if (dic_entry) {
+            (void)snprintf(buf, sizeof(buf), "out_%s", dic_entry->value);
+            print_id_noprefix("dest_filter_id", buf);
+        } else {
+            print_id("dest_filter_id", link->dst->name);
+        }
+
+        print_int_opt("output_index", i);
+        print_str_opt("pad_name", get_filterpad_name(link->srcpad));
+        ////print_id("dest_filter_id", link->dst->name);
+        print_str_opt("dest_pad_name", get_filterpad_name(link->dstpad));
+        print_id("filter_id", filter->name);
+
+        print_link(gpc, link);
+
+        avtext_print_section_footer(tfc); // SECTION_ID_FILTER_OUTPUT
+    }
+
+    avtext_print_section_footer(tfc); // SECTION_ID_FILTER_OUTPUTS
+
+    avtext_print_section_footer(tfc); // SECTION_ID_FILTER
+}
+
+static void init_sections(void)
+{
+    for (unsigned i = 0; i < FF_ARRAY_ELEMS(sections); i++)
+        sections[i].show_all_entries = 1;
+}
+
+static void print_filtergraph_single(GraphPrintContext *gpc, FilterGraph *fg, AVFilterGraph *graph)
+{
+    AVTextFormatContext *tfc = gpc->tfc;
+    FilterGraphPriv *fgp = fgp_from_fg(fg);
+    AVDictionary *input_map = NULL;
+    AVDictionary *output_map = NULL;
+
+    print_int("graph_index", fg->index);
+    print_fmt("name", "Graph %d.%d", gpc->id_prefix_num, fg->index);
+    print_fmt("id", "Graph_%d_%d", gpc->id_prefix_num, fg->index);
+    print_str("description", fgp->graph_desc);
+
+    print_section_header_id(gpc, SECTION_ID_GRAPH_INPUTS, "Input_File", 0);
+
+    for (int i = 0; i < fg->nb_inputs; i++) {
+        InputFilterPriv *ifilter = ifp_from_ifilter(fg->inputs[i]);
+        enum AVMediaType media_type = ifilter->type;
+
+        avtext_print_section_header(tfc, NULL, SECTION_ID_GRAPH_INPUT);
+
+        print_int("input_index", ifilter->index);
+
+        if (ifilter->linklabel)
+            print_str("link_label", (const char*)ifilter->linklabel);
+
+        if (ifilter->filter) {
+            print_id("filter_id", ifilter->filter->name);
+            print_str("filter_name", ifilter->filter->filter->name);
+        }
+
+        if (ifilter->linklabel && ifilter->filter)
+            av_dict_set(&input_map, ifilter->filter->name, (const char *)ifilter->linklabel, 0);
+        else if (ifilter->opts.name && ifilter->filter)
+            av_dict_set(&input_map, ifilter->filter->name, (const char *)ifilter->opts.name, 0);
+
+        print_str("media_type", av_get_media_type_string(media_type));
+
+        avtext_print_section_footer(tfc); // SECTION_ID_GRAPH_INPUT
+    }
+
+    avtext_print_section_footer(tfc); // SECTION_ID_GRAPH_INPUTS
+
+    print_section_header_id(gpc, SECTION_ID_GRAPH_OUTPUTS, "Output_File", 0);
+
+    for (int i = 0; i < fg->nb_outputs; i++) {
+        OutputFilterPriv *ofilter = ofp_from_ofilter(fg->outputs[i]);
+
+        avtext_print_section_header(tfc, NULL, SECTION_ID_GRAPH_OUTPUT);
+
+        print_int("output_index", ofilter->index);
+
+        print_str("name", ofilter->name);
+
+        if (fg->outputs[i]->linklabel)
+            print_str("link_label", (const char*)fg->outputs[i]->linklabel);
+
+        if (ofilter->filter) {
+            print_id("filter_id", ofilter->filter->name);
+            print_str("filter_name", ofilter->filter->filter->name);
+        }
+
+        if (ofilter->name && ofilter->filter)
+            av_dict_set(&output_map, ofilter->filter->name, ofilter->name, 0);
+
+
+        print_str("media_type", av_get_media_type_string(fg->outputs[i]->type));
+
+        avtext_print_section_footer(tfc); // SECTION_ID_GRAPH_OUTPUT
+    }
+
+    avtext_print_section_footer(tfc); // SECTION_ID_GRAPH_OUTPUTS
+
+    if (graph) {
+        AVTextFormatSectionContext sec_ctx = { 0 };
+
+        sec_ctx.context_id = av_asprintf("Graph_%d_%d", gpc->id_prefix_num, fg->index);
+
+        avtext_print_section_header(tfc, &sec_ctx, SECTION_ID_FILTERS);
+
+        if (gpc->is_diagram) {
+            print_fmt("name", "Graph %d.%d", gpc->id_prefix_num, fg->index);
+            print_str("description", fgp->graph_desc);
+            print_str("id", sec_ctx.context_id);
+        }
+
+        av_freep(&sec_ctx.context_id);
+
+        for (unsigned i = 0; i < graph->nb_filters; i++) {
+            AVFilterContext *filter = graph->filters[i];
+
+            if (gpc->skip_buffer_filters) {
+                if (av_dict_get(input_map, filter->name, NULL, 0))
+                    continue;
+                if (av_dict_get(output_map, filter->name, NULL, 0))
+                    continue;
+            }
+
+            sec_ctx.context_id = filter->name;
+
+            print_filter(gpc, filter, input_map, output_map);
+        }
+
+        avtext_print_section_footer(tfc); // SECTION_ID_FILTERS
+    }
+
+    // Clean up dictionaries
+    av_dict_free(&input_map);
+    av_dict_free(&output_map);
+}
+
+static int print_streams(GraphPrintContext *gpc, InputFile **ifiles, int nb_ifiles, OutputFile **ofiles, int nb_ofiles)
+{
+    AVTextFormatContext       *tfc = gpc->tfc;
+    AVBPrint                   buf;
+    AVTextFormatSectionContext sec_ctx = { 0 };
+
+    av_bprint_init(&buf, 0, AV_BPRINT_SIZE_UNLIMITED);
+
+    print_section_header_id(gpc, SECTION_ID_INPUTFILES, "Inputs", 0);
+
+    for (int n = nb_ifiles - 1; n >= 0; n--) {
+        InputFile *ifi = ifiles[n];
+        AVFormatContext *fc = ifi->ctx;
+
+        sec_ctx.context_id = av_asprintf("Input_%d", n);
+        avtext_print_section_header(tfc, &sec_ctx, SECTION_ID_INPUTFILE);
+        av_freep(&sec_ctx.context_id);
+
+        print_fmt("index", "%d", ifi->index);
+
+        if (fc) {
+            print_str("demuxer_name", fc->iformat->name);
+            if (fc->url) {
+                char *extension = get_extension(fc->url);
+                if (extension) {
+                    print_str("file_extension", extension);
+                    av_freep(&extension);
+                }
+                print_str("url", fc->url);
+            }
+        }
+
+        sec_ctx.context_id = av_asprintf("InputStreams_%d", n);
+
+        avtext_print_section_header(tfc, &sec_ctx, SECTION_ID_INPUTSTREAMS);
+
+        av_freep(&sec_ctx.context_id);
+
+        for (int i = 0; i < ifi->nb_streams; i++) {
+            InputStream *ist = ifi->streams[i];
+            const AVCodecDescriptor *codec_desc;
+
+            if (!ist || !ist->par)
+                continue;
+
+            codec_desc = avcodec_descriptor_get(ist->par->codec_id);
+
+            sec_ctx.context_id = av_asprintf("r_in_%d_%d", n, i);
+
+            sec_ctx.context_type = av_get_media_type_string(ist->par->codec_type);
+
+            avtext_print_section_header(tfc, &sec_ctx, SECTION_ID_INPUTSTREAM);
+            av_freep(&sec_ctx.context_id);
+            sec_ctx.context_type = NULL;
+
+            av_bprint_clear(&buf);
+
+            print_fmt("id", "r_in_%d_%d", n, i);
+
+            if (codec_desc && codec_desc->name) {
+                ////av_bprintf(&buf, "%s", upcase_string(char_buf, sizeof(char_buf), codec_desc->long_name));
+                av_bprintf(&buf, "%s", codec_desc->long_name);
+            } else if (ist->dec) {
+                char char_buf[256];
+                av_bprintf(&buf, "%s", upcase_string(char_buf, sizeof(char_buf), ist->dec->name));
+            } else if (ist->par->codec_type == AVMEDIA_TYPE_ATTACHMENT) {
+                av_bprintf(&buf, "%s", "Attachment");
+            } else if (ist->par->codec_type == AVMEDIA_TYPE_DATA) {
+                av_bprintf(&buf, "%s", "Data");
+            }
+
+            print_fmt("name", "%s", buf.str);
+            print_fmt("index", "%d", ist->index);
+
+            if (ist->dec)
+                print_str_opt("media_type", av_get_media_type_string(ist->par->codec_type));
+
+            avtext_print_section_footer(tfc); // SECTION_ID_INPUTSTREAM
+        }
+
+        avtext_print_section_footer(tfc); // SECTION_ID_INPUTSTREAMS
+        avtext_print_section_footer(tfc); // SECTION_ID_INPUTFILE
+    }
+
+    avtext_print_section_footer(tfc); // SECTION_ID_INPUTFILES
+
+
+    print_section_header_id(gpc, SECTION_ID_DECODERS, "Decoders", 0);
+
+    for (int n = 0; n < nb_ifiles; n++) {
+        InputFile *ifi = ifiles[n];
+
+        for (int i = 0; i < ifi->nb_streams; i++) {
+            InputStream *ist = ifi->streams[i];
+
+            if (!ist->decoder)
+                continue;
+
+            sec_ctx.context_id = av_asprintf("in_%d_%d", n, i);
+            sec_ctx.context_type = av_get_media_type_string(ist->par->codec_type);
+            sec_ctx.context_flags = 2;
+
+            avtext_print_section_header(tfc, &sec_ctx, SECTION_ID_DECODER);
+            av_freep(&sec_ctx.context_id);
+            sec_ctx.context_type = NULL;
+            sec_ctx.context_flags = 0;
+
+            av_bprint_clear(&buf);
+
+            print_fmt("source_id", "r_in_%d_%d", n, i);
+            print_fmt("id", "in_%d_%d", n, i);
+
+            ////av_bprintf(&buf, "%s", upcase_string(char_buf, sizeof(char_buf), ist->dec->name));
+            print_fmt("name", "%s", ist->dec->name);
+
+            print_str_opt("media_type", av_get_media_type_string(ist->par->codec_type));
+
+            avtext_print_section_footer(tfc); // SECTION_ID_DECODER
+        }
+    }
+
+    avtext_print_section_footer(tfc); // SECTION_ID_DECODERS
+
+
+    print_section_header_id(gpc, SECTION_ID_ENCODERS, "Encoders", 0);
+
+    for (int n = 0; n < nb_ofiles; n++) {
+        OutputFile *of = ofiles[n];
+
+        for (int i = 0; i < of->nb_streams; i++) {
+            OutputStream *ost = of->streams[i];
+            ////const AVCodecDescriptor *codec_desc;
+
+            if (!ost || !ost->st || !ost->st->codecpar || !ost->enc)
+                continue;
+
+            ////codec_desc = avcodec_descriptor_get(ost->st->codecpar->codec_id);
+
+            sec_ctx.context_id = av_asprintf("out__%d_%d", n, i);
+            sec_ctx.context_type = av_get_media_type_string(ost->type);
+            sec_ctx.context_flags = 2;
+
+            avtext_print_section_header(tfc, &sec_ctx, SECTION_ID_ENCODER);
+            av_freep(&sec_ctx.context_id);
+            sec_ctx.context_type = NULL;
+            sec_ctx.context_flags = 0;
+
+            av_bprint_clear(&buf);
+
+            print_fmt("id", "out__%d_%d", n, i);
+            print_fmt("dest_id", "r_out__%d_%d", n, i);
+
+            print_fmt("name", "%s", ost->enc->enc_ctx->av_class->item_name(ost->enc->enc_ctx));
+
+            print_str_opt("media_type", av_get_media_type_string(ost->type));
+
+            avtext_print_section_footer(tfc); // SECTION_ID_ENCODER
+        }
+    }
+
+    avtext_print_section_footer(tfc); // SECTION_ID_ENCODERS
+
+
+    print_section_header_id(gpc, SECTION_ID_OUTPUTFILES, "Outputs", 0);
+
+    for (int n = nb_ofiles - 1; n >= 0; n--) {
+        OutputFile *of = ofiles[n];
+        Muxer *muxer = (Muxer *)of;
+
+        if (!muxer->fc)
+            continue;
+
+        sec_ctx.context_id = av_asprintf("Output_%d", n);
+
+        avtext_print_section_header(tfc, &sec_ctx, SECTION_ID_OUTPUTFILE);
+
+        av_freep(&sec_ctx.context_id);
+
+        ////print_str_opt("index", av_get_media_type_string(of->index));
+        print_fmt("index", "%d", of->index);
+        ////print_str("url", of->url);
+        print_str("muxer_name", muxer->fc->oformat->name);
+        if (of->url) {
+            char *extension = get_extension(of->url);
+            if (extension) {
+                print_str("file_extension", extension);
+                av_freep(&extension);
+            }
+            print_str("url", of->url);
+        }
+
+        sec_ctx.context_id = av_asprintf("OutputStreams_%d", n);
+
+        avtext_print_section_header(tfc, &sec_ctx, SECTION_ID_OUTPUTSTREAMS);
+
+        for (int i = 0; i < of->nb_streams; i++) {
+            OutputStream *ost = of->streams[i];
+            const AVCodecDescriptor *codec_desc = avcodec_descriptor_get(ost->st->codecpar->codec_id);
+
+            sec_ctx.context_id = av_asprintf("r_out__%d_%d", n, i);
+            sec_ctx.context_type = av_get_media_type_string(ost->type);
+            avtext_print_section_header(tfc, &sec_ctx, SECTION_ID_OUTPUTSTREAM);
+            av_freep(&sec_ctx.context_id);
+            sec_ctx.context_type = NULL;
+
+            av_bprint_clear(&buf);
+
+            print_fmt("id", "r_out__%d_%d", n, i);
+
+            if (codec_desc && codec_desc->name) {
+                av_bprintf(&buf, "%s", codec_desc->long_name);
+            } else {
+                av_bprintf(&buf, "%s", "unknown");
+            }
+
+            print_fmt("name", "%s", buf.str);
+            print_fmt("index", "%d", ost->index);
+
+            print_str_opt("media_type", av_get_media_type_string(ost->type));
+
+            avtext_print_section_footer(tfc); // SECTION_ID_OUTPUTSTREAM
+        }
+
+        avtext_print_section_footer(tfc); // SECTION_ID_OUTPUTSTREAMS
+        avtext_print_section_footer(tfc); // SECTION_ID_OUTPUTFILE
+    }
+
+    avtext_print_section_footer(tfc); // SECTION_ID_OUTPUTFILES
+
+
+    avtext_print_section_header(tfc, NULL, SECTION_ID_STREAMLINKS);
+
+    for (int n = 0; n < nb_ofiles; n++) {
+        OutputFile *of = ofiles[n];
+
+        for (int i = 0; i < of->nb_streams; i++) {
+            OutputStream *ost = of->streams[i];
+
+            if (ost->ist && !ost->filter) {
+                sec_ctx.context_type = av_get_media_type_string(ost->type);
+                avtext_print_section_header(tfc, &sec_ctx, SECTION_ID_STREAMLINK);
+                sec_ctx.context_type = NULL;
+
+                if (ost->enc) {
+                    print_fmt("dest_stream_id", "out__%d_%d", n, i);
+                    print_fmt("source_stream_id", "in_%d_%d", ost->ist->file->index, ost->ist->index);
+                    print_str("operation", "Transcode");
+                } else {
+                    print_fmt("dest_stream_id", "r_out__%d_%d", n, i);
+                    print_fmt("source_stream_id", "r_in_%d_%d", ost->ist->file->index, ost->ist->index);
+                    print_str("operation", "Stream Copy");
+                }
+
+                print_str_opt("media_type", av_get_media_type_string(ost->type));
+
+                avtext_print_section_footer(tfc); // SECTION_ID_STREAMLINK
+            }
+        }
+    }
+
+    avtext_print_section_footer(tfc); // SECTION_ID_STREAMLINKS
+
+    av_bprint_finalize(&buf, NULL);
+    return 0;
+}
+
+
+static void uninit_graphprint(GraphPrintContext *gpc)
+{
+    if (gpc->tfc)
+        avtext_context_close(&gpc->tfc);
+
+    if (gpc->wctx)
+        avtextwriter_context_close(&gpc->wctx);
+
+    // Finalize the print buffer if it was initialized
+    av_bprint_finalize(&gpc->pbuf, NULL);
+}
+
+static int init_graphprint(GraphPrintContext **pgpc, AVBPrint *target_buf)
+{
+    const AVTextFormatter *text_formatter;
+    AVTextFormatContext *tfc = NULL;
+    AVTextWriterContext *wctx = NULL;
+    GraphPrintContext *gpc = NULL;
+    char *w_args = NULL;
+    char *w_name;
+    int ret;
+
+    init_sections();
+    *pgpc = NULL;
+
+    av_bprint_init(target_buf, 0, AV_BPRINT_SIZE_UNLIMITED);
+
+    if (!print_graphs_format)
+        print_graphs_format = av_strdup("json");
+    if (!print_graphs_format) {
+        ret = AVERROR(ENOMEM);
+        goto fail;
+    }
+
+    w_name = av_strtok(print_graphs_format, "=", &w_args);
+    if (!w_name) {
+        av_log(NULL, AV_LOG_ERROR, "No name specified for the filter graph output format\n");
+        ret = AVERROR(EINVAL);
+        goto fail;
+    }
+
+    text_formatter = avtext_get_formatter_by_name(w_name);
+    if (!text_formatter) {
+        av_log(NULL, AV_LOG_ERROR, "Unknown filter graph output format with name '%s'\n", w_name);
+        ret = AVERROR(EINVAL);
+        goto fail;
+    }
+
+    ret = avtextwriter_create_buffer(&wctx, target_buf);
+    if (ret < 0) {
+        av_log(NULL, AV_LOG_ERROR, "avtextwriter_create_buffer failed. Error code %d\n", ret);
+        ret = AVERROR(EINVAL);
+        goto fail;
+    }
+
+    AVTextFormatOptions tf_options = { .show_optional_fields = -1 };
+    ret = avtext_context_open(&tfc, text_formatter, wctx, w_args, sections, FF_ARRAY_ELEMS(sections), tf_options, NULL);
+    if (ret < 0) {
+        goto fail;
+    }
+
+    gpc = av_mallocz(sizeof(GraphPrintContext));
+    if (!gpc) {
+        ret = AVERROR(ENOMEM);
+        goto fail;
+    }
+
+    gpc->wctx = wctx;
+    gpc->tfc = tfc;
+    av_bprint_init(&gpc->pbuf, 0, AV_BPRINT_SIZE_UNLIMITED);
+
+    gpc->id_prefix_num = atomic_fetch_add(&prefix_num, 1);
+    gpc->is_diagram = !!(tfc->formatter->flags & AV_TEXTFORMAT_FLAG_IS_DIAGRAM_FORMATTER);
+    if (gpc->is_diagram) {
+        tfc->show_value_unit = 1;
+        tfc->show_optional_fields = -1;
+        gpc->opt_flags = AV_TEXTFORMAT_PRINT_STRING_OPTIONAL;
+        gpc->skip_buffer_filters = 1;
+        ////} else {
+        ////    gpc->opt_flags = AV_TEXTFORMAT_PRINT_STRING_OPTIONAL;
+    }
+
+    if (!strcmp(text_formatter->name, "mermaid") || !strcmp(text_formatter->name, "mermaidhtml")) {
+        gpc->diagram_config.diagram_css = ff_resman_get_string(FF_RESOURCE_GRAPH_CSS);
+
+        if (!strcmp(text_formatter->name, "mermaidhtml"))
+            gpc->diagram_config.html_template = ff_resman_get_string(FF_RESOURCE_GRAPH_HTML);
+
+        av_diagram_init(tfc, &gpc->diagram_config);
+    }
+
+    *pgpc = gpc;
+
+    return 0;
+
+fail:
+    if (tfc)
+        avtext_context_close(&tfc);
+    if (wctx && !tfc) // Only free wctx if tfc didn't take ownership of it
+        avtextwriter_context_close(&wctx);
+    av_freep(&gpc);
+
+    return ret;
+}
+
+
+int print_filtergraph(FilterGraph *fg, AVFilterGraph *graph)
+{
+    GraphPrintContext *gpc = NULL;
+    AVTextFormatContext *tfc;
+    FilterGraphPriv *fgp = fgp_from_fg(fg);
+    AVBPrint *target_buf = &fgp->graph_print_buf;
+    int ret;
+
+    if (!fg || !fgp) {
+        av_log(NULL, AV_LOG_ERROR, "Invalid filter graph provided\n");
+        return AVERROR(EINVAL);
+    }
+
+    if (target_buf->len)
+        av_bprint_finalize(target_buf, NULL);
+
+    ret = init_graphprint(&gpc, target_buf);
+    if (ret)
+        return ret;
+
+    if (!gpc) {
+        av_log(NULL, AV_LOG_ERROR, "Failed to initialize graph print context\n");
+        return AVERROR(ENOMEM);
+    }
+
+    tfc = gpc->tfc;
+
+    // Due to the threading model each graph needs to print itself into a buffer
+    // from its own thread. The actual printing happens short before cleanup in ffmpeg.c
+    // where all graphs are assembled together. To make this work, we need to put the
+    // formatting context into the same state like it would be when printing all at once,
+    // so here we print the section headers and clear the buffer to get into the right state.
+    avtext_print_section_header(tfc, NULL, SECTION_ID_ROOT);
+    avtext_print_section_header(tfc, NULL, SECTION_ID_FILTERGRAPHS);
+    avtext_print_section_header(tfc, NULL, SECTION_ID_FILTERGRAPH);
+
+    av_bprint_clear(target_buf);
+
+    print_filtergraph_single(gpc, fg, graph);
+
+    if (gpc->is_diagram) {
+        avtext_print_section_footer(tfc); // SECTION_ID_FILTERGRAPH
+        avtext_print_section_footer(tfc); // SECTION_ID_FILTERGRAPHS
+    }
+
+    uninit_graphprint(gpc);
+
+    return 0;
+}
+
+static int print_filtergraphs_priv(FilterGraph **graphs, int nb_graphs, InputFile **ifiles, int nb_ifiles, OutputFile **ofiles, int nb_ofiles)
+{
+    GraphPrintContext *gpc = NULL;
+    AVTextFormatContext *tfc;
+    AVBPrint target_buf;
+    int ret;
+
+    ret = init_graphprint(&gpc, &target_buf);
+    if (ret)
+        goto cleanup;
+
+    if (!gpc) {
+        ret = AVERROR(ENOMEM);
+        goto cleanup;
+    }
+
+    tfc = gpc->tfc;
+
+    avtext_print_section_header(tfc, NULL, SECTION_ID_ROOT);
+    avtext_print_section_header(tfc, NULL, SECTION_ID_FILTERGRAPHS);
+
+    for (int i = 0; i < nb_graphs; i++) {
+        FilterGraphPriv *fgp = fgp_from_fg(graphs[i]);
+        AVBPrint *graph_buf = &fgp->graph_print_buf;
+
+        if (graph_buf->len > 0) {
+            avtext_print_section_header(tfc, NULL, SECTION_ID_FILTERGRAPH);
+            av_bprint_append_data(&target_buf, graph_buf->str, graph_buf->len);
+            av_bprint_finalize(graph_buf, NULL);
+            avtext_print_section_footer(tfc); // SECTION_ID_FILTERGRAPH
+        }
+    }
+
+    for (int n = 0; n < nb_ofiles; n++) {
+        OutputFile *of = ofiles[n];
+
+        for (int i = 0; i < of->nb_streams; i++) {
+            OutputStream *ost = of->streams[i];
+
+            if (ost->fg_simple) {
+                FilterGraphPriv *fgp = fgp_from_fg(ost->fg_simple);
+                AVBPrint *graph_buf = &fgp->graph_print_buf;
+
+                if (graph_buf->len > 0) {
+                    avtext_print_section_header(tfc, NULL, SECTION_ID_FILTERGRAPH);
+                    av_bprint_append_data(&target_buf, graph_buf->str, graph_buf->len);
+                    av_bprint_finalize(graph_buf, NULL);
+                    avtext_print_section_footer(tfc); // SECTION_ID_FILTERGRAPH
+                }
+            }
+        }
+    }
+
+    avtext_print_section_footer(tfc); // SECTION_ID_FILTERGRAPHS
+
+    print_streams(gpc, ifiles, nb_ifiles, ofiles, nb_ofiles);
+
+    avtext_print_section_footer(tfc); // SECTION_ID_ROOT
+
+    if (print_graphs_file) {
+        AVIOContext *avio = NULL;
+
+        if (!strcmp(print_graphs_file, "-")) {
+            printf("%s", target_buf.str);
+        } else {
+            ret = avio_open2(&avio, print_graphs_file, AVIO_FLAG_WRITE, NULL, NULL);
+            if (ret < 0) {
+                av_log(NULL, AV_LOG_ERROR, "Failed to open graph output file, \"%s\": %s\n", print_graphs_file, av_err2str(ret));
+                goto cleanup;
+            }
+
+            avio_write(avio, (const unsigned char *)target_buf.str, FFMIN(target_buf.len, target_buf.size - 1));
+            avio_flush(avio);
+
+            if ((ret = avio_closep(&avio)) < 0)
+                av_log(NULL, AV_LOG_ERROR, "Error closing graph output file, loss of information possible: %s\n", av_err2str(ret));
+        }
+    }
+
+    if (print_graphs)
+        av_log(NULL, AV_LOG_INFO, "%s    %c", target_buf.str, '\n');
+
+cleanup:
+    // Properly clean up resources
+    if (gpc)
+        uninit_graphprint(gpc);
+
+    // Ensure the target buffer is properly finalized
+    av_bprint_finalize(&target_buf, NULL);
+
+    return ret;
+}
+
+int print_filtergraphs(FilterGraph **graphs, int nb_graphs, InputFile **ifiles, int nb_ifiles, OutputFile **ofiles, int nb_ofiles)
+{
+    return print_filtergraphs_priv(graphs, nb_graphs, ifiles, nb_ifiles, ofiles, nb_ofiles);
+}

--- a/fftools/graph/graphprint.h
+++ b/fftools/graph/graphprint.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018-2025 - softworkz
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef FFTOOLS_GRAPH_GRAPHPRINT_H
+#define FFTOOLS_GRAPH_GRAPHPRINT_H
+
+#include "fftools/ffmpeg.h"
+
+int print_filtergraphs(FilterGraph **graphs, int nb_graphs, InputFile **ifiles, int nb_ifiles, OutputFile **ofiles, int nb_ofiles);
+
+int print_filtergraph(FilterGraph *fg, AVFilterGraph *graph);
+
+#endif /* FFTOOLS_GRAPH_GRAPHPRINT_H */

--- a/fftools/graph/graphprint.h
+++ b/fftools/graph/graphprint.h
@@ -27,4 +27,36 @@ int print_filtergraphs(FilterGraph **graphs, int nb_graphs, InputFile **ifiles, 
 
 int print_filtergraph(FilterGraph *fg, AVFilterGraph *graph);
 
+/**
+ * Open an HTML file in the default browser (Windows, macOS, Linux/Unix).
+ *
+ * @param html_path Absolute or relative path to the HTML file.
+ * @return 0 on success, -1 on failure.
+ *
+ * NOTE: This uses system() calls for non-Windows, and ShellExecute on Windows.
+ *       Exercise caution if 'html_path' is untrusted (possible command injection).
+ */
+int ff_open_html_in_browser(const char *html_path);
+
+/**
+ * Retrieve the system's temporary directory.
+ *
+ * @param buf  Output buffer to store the temp directory path (including trailing slash)
+ * @param size Size of the output buffer in bytes
+ * @return 0 on success, -1 on failure (buffer too small or other errors)
+ *
+ * Note: On most platforms, the path will include a trailing slash (e.g. "C:\\Users\\...\\Temp\\" on Windows, "/tmp/" on Unix).
+ */
+int ff_get_temp_dir(char *buf, size_t size);
+
+/**
+ * Create a timestamped HTML filename, e.g.:
+ *   ffmpeg_graph_2024-01-01_22-12-59_123.html
+ *
+ * @param buf  Pointer to buffer where the result is stored
+ * @param size Size of the buffer in bytes
+ * @return 0 on success, -1 on error (e.g. buffer too small)
+ */
+int ff_make_timestamped_html_name(char *buf, size_t size);
+
 #endif /* FFTOOLS_GRAPH_GRAPHPRINT_H */

--- a/fftools/resources/.gitignore
+++ b/fftools/resources/.gitignore
@@ -1,0 +1,4 @@
+*.html.c
+*.css.c
+*.html.gz
+*.css.gz

--- a/fftools/resources/Makefile
+++ b/fftools/resources/Makefile
@@ -1,0 +1,13 @@
+clean::
+	$(RM) $(CLEANSUFFIXES:%=fftools/resources/%)
+
+vpath %.html $(SRC_PATH)
+vpath %.css  $(SRC_PATH)
+
+# Uncomment to prevent deletion during build
+#.PRECIOUS: %.css.c %.css.min %.css.gz %.css.min.gz %.html.gz %.html.c
+
+OBJS-resman +=                     \
+    fftools/resources/resman.o     \
+    fftools/resources/graph.html.o \
+    fftools/resources/graph.css.o  \

--- a/fftools/resources/graph.css
+++ b/fftools/resources/graph.css
@@ -1,0 +1,353 @@
+/* Variables */
+.root {
+    --ff-colvideo: #6eaa7b;
+    --ff-colaudio: #477fb3;
+    --ff-colsubtitle: #ad76ab;
+    --ff-coltext: #666;
+}
+
+/* Common & Misc */
+.ff-inputfiles rect, .ff-outputfiles rect, .ff-inputstreams rect, .ff-outputstreams rect, .ff-decoders rect, .ff-encoders rect {
+    stroke-width: 0;
+    stroke: transparent;
+    filter: none !important;
+    fill: transparent !important;
+    display: none !important;
+}
+
+.cluster span {
+    color: var(--ff-coltext);
+}
+
+.cluster rect {
+    stroke: #dfdfdf !important;
+    transform: translateY(-2.3rem);
+    filter: drop-shadow(1px 2px 2px rgba(185,185,185,0.2)) !important;
+    rx: 8;
+    ry: 8;
+}
+
+.cluster-label {
+    font-size: 1.1rem;
+}
+
+    .cluster-label .nodeLabel {
+        display: block;
+        font-weight: 500;
+        color: var(--ff-coltext);
+    }
+
+    .cluster-label div {
+        max-width: unset !important;
+        padding: 3px;
+    }
+
+    .cluster-label foreignObject {
+        transform: translateY(-0.7rem);
+    }
+
+/* Input and output files */
+.node.ff-inputfile .label foreignObject, .node.ff-outputfile .label foreignObject {
+    overflow: visible;
+}
+
+.cluster.ff-inputfile .cluster-label foreignObject div:not(foreignObject div div), .cluster.ff-outputfile .cluster-label foreignObject div:not(foreignObject div div) {
+    display: table !important;
+}
+
+.nodeLabel div.ff-inputfile, .nodeLabel div.ff-outputfile {
+    font-size: 1.1rem;
+    font-weight: 500;
+    min-width: 14rem;
+    width: 100%;
+    display: flex;
+    color: var(--ff-coltext);
+    margin-top: 0.1rem;
+    line-height: 1.35;
+    padding-bottom: 1.9rem;
+}
+
+.nodeLabel div.ff-outputfile {
+    flex-direction: row-reverse;
+}
+
+.ff-inputfile .index, .ff-outputfile .index {
+    order: 2;
+    color: var(--ff-coltext);
+    text-align: center;
+    border-radius: 0.45rem;
+    border: 0.18em solid #666666db;
+    font-weight: 600;
+    padding: 0 0.3em;
+    opacity: 0.8;
+}
+
+    .ff-inputfile .index::before {
+        content: 'In ';
+    }
+
+    .ff-outputfile .index::before {
+        content: 'Out ';
+    }
+
+.ff-inputfile .demuxer_name, .ff-outputfile .muxer_name {
+    flex: 1;
+    order: 1;
+    font-size: 0.9rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: center;
+    max-width: 8rem;
+    align-content: center;
+    margin: 0.2rem 0.4rem 0 0.4rem;
+}
+
+.ff-inputfile .file_extension, .ff-outputfile .file_extension {
+    order: 0;
+    background-color: #888;
+    color: white;
+    text-align: center;
+    border-radius: 0.45rem;
+    font-weight: 600;
+    padding: 0 0.4em;
+    align-content: center;
+    opacity: 0.8;
+}
+
+.ff-inputfile .url, .ff-outputfile .url {
+    order: 4;
+    text-align: center;
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0.75rem;
+    font-size: 0.7rem;
+    font-weight: 400;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin: 0 0.3rem;
+    direction: rtl;
+    color: #999;
+}
+
+.cluster.ff-inputfile rect, .cluster.ff-outputfile rect {
+    transform: translateY(-1.8rem);
+    fill: url(#ff-radgradient);
+}
+
+/* Input and output streams */
+.node.ff-inputstream rect, .node.ff-outputstream rect {
+    padding: 0 !important;
+    margin: 0 !important;
+    border: none !important;
+    fill: white;
+    stroke: #e5e5e5 !important;
+    height: 2.7rem;
+    transform: translateY(0.2rem);
+    filter: none;
+    rx: 3;
+    ry: 3;
+}
+
+.node.ff-inputstream .label foreignObject, .node.ff-outputstream .label foreignObject {
+    transform: translateY(-0.2%);
+    overflow: visible;
+}
+
+    .node.ff-inputstream .label foreignObject div:not(foreignObject div div), .node.ff-outputstream .label foreignObject div:not(foreignObject div div) {
+        display: block !important;
+        line-height: 1.5 !important;
+    }
+
+.nodeLabel div.ff-inputstream, .nodeLabel div.ff-outputstream {
+    font-size: 1.0rem;
+    font-weight: 500;
+    min-width: 12rem;
+    width: 100%;
+    display: flex;
+}
+
+.nodeLabel div.ff-outputstream {
+    flex-direction: row-reverse;
+}
+
+.ff-inputstream .name, .ff-outputstream .name {
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: left;
+    align-content: center;
+    margin-bottom: -0.15rem;
+}
+
+.ff-inputstream .index, .ff-outputstream .index {
+    flex: 0 0 1.4rem;
+    background-color: #888;
+    color: white;
+    text-align: center;
+    border-radius: 0.3rem;
+    font-weight: 600;
+    margin-right: -0.3rem;
+    margin-left: 0.4rem;
+    opacity: 0.8;
+}
+
+.ff-outputstream .index {
+    margin-right: 0.6rem;
+    margin-left: -0.4rem;
+}
+
+.ff-inputstream::before, .ff-outputstream::before {
+    font-variant-emoji: text;
+    flex: 0 0 2rem;
+    margin-left: -0.8rem;
+    margin-right: 0.2rem;
+}
+
+.ff-outputstream::before {
+    margin-left: 0.2rem;
+    margin-right: -0.6rem;
+}
+
+.ff-inputstream.video::before, .ff-outputstream.video::before {
+    content: '\239A';
+    color: var(--ff-colvideo);
+    font-size: 2.25rem;
+    line-height: 0.5;
+    font-weight: bold;
+}
+
+.ff-inputstream.audio::before, .ff-outputstream.audio::before {
+    content: '\1F39D';
+    color: var(--ff-colaudio);
+    font-size: 1.75rem;
+    line-height: 0.9;
+}
+
+.ff-inputstream.subtitle::before, .ff-outputstream.subtitle::before {
+    content: '\1AC';
+    color: var(--ff-colsubtitle);
+    font-size: 1.2rem;
+    line-height: 1.1;
+    transform: scaleX(1.5);
+    margin-top: 0.050rem;
+}
+
+.ff-inputstream.attachment::before, .ff-outputstream.attachment::before {
+    content: '\1F4CE';
+    font-size: 1.3rem;
+    line-height: 1.15;
+}
+
+.ff-inputstream.data::before, .ff-outputstream.data::before {
+    content: '\27E8\2219\2219\2219\27E9';
+    font-size: 1.15rem;
+    line-height: 1.17;
+    letter-spacing: -0.3px;
+}
+
+/* Filter Graphs */
+.cluster.ff-filters rect {
+    stroke-dasharray: 6 !important;
+    stroke-width: 1.3px;
+    stroke: #d1d1d1 !important;
+    filter: none !important;
+}
+
+.cluster.ff-filters div.ff-filters .id {
+    display: none;
+}
+
+.cluster.ff-filters div.ff-filters .name {
+    margin-right: 0.5rem;
+    font-size: 0.9rem;
+}
+
+.cluster.ff-filters div.ff-filters .description {
+    font-weight: 400;
+    font-size: 0.75rem;
+    vertical-align: middle;
+    color: #777;
+    font-family: Cascadia Code, Lucida Console, monospace;
+}
+
+/* Filter Shapes */
+.node.ff-filter rect {
+    rx: 10;
+    ry: 10;
+    stroke-width: 1px;
+    stroke: #d3d3d3;
+    fill: url(#ff-filtergradient);
+    filter: drop-shadow(1px 1px 2px rgba(0, 0, 0, 0.1));
+}
+
+.node.ff-filter .label foreignObject {
+    transform: translateY(-0.4rem);
+    overflow: visible;
+}
+
+.nodeLabel div.ff-filter {
+    font-size: 1.0rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    min-width: 5.5rem;
+    margin-bottom: 0.5rem;
+}
+
+    .nodeLabel div.ff-filter span {
+        color: inherit;
+    }
+
+/* Decoders & Encoders */
+.node.ff-decoder rect, .node.ff-encoder rect {
+    stroke-width: 1px;
+    stroke: #d3d3d3;
+    fill: url(#ff-filtergradient);
+    filter: drop-shadow(1px 1px 2px rgba(0, 0, 0, 0.1));
+}
+
+.nodeLabel div.ff-decoder, .nodeLabel div.ff-encoder {
+    font-size: 0.85rem;
+    font-weight: 500;
+    min-width: 3.5rem;
+}
+
+/* Links and Arrows */
+path.flowchart-link[id|='video'] {
+    stroke: var(--ff-colvideo);
+}
+
+path.flowchart-link[id|='audio'] {
+    stroke: var(--ff-colaudio);
+}
+
+path.flowchart-link[id|='subtitle'] {
+    stroke: var(--ff-colsubtitle);
+}
+
+marker.marker path {
+    fill: context-stroke;
+}
+
+.edgeLabel foreignObject {
+    transform: translateY(-1rem);
+}
+
+.edgeLabel p {
+    background: transparent;
+    white-space: nowrap;
+    margin: 1rem 0.5rem !important;
+    font-weight: 500;
+    color: var(--ff-coltext);
+}
+
+.edgeLabel, .labelBkg {
+    background: transparent;
+}
+
+.edgeLabels .edgeLabel * {
+    font-size: 0.8rem;
+}

--- a/fftools/resources/graph.html
+++ b/fftools/resources/graph.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <title>FFmpeg Graph</title>
+</head>
+<body>
+<style>
+    html {
+        color: #666;
+        font-family: Roboto;
+        height: 100%;
+    }
+
+    body {
+        background-color: #f9f9f9;
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        margin: 0;
+        padding: 1.7rem 1.7rem 3.5rem 1.7rem;
+    }
+
+    div#banner {
+        align-items: center;
+        display: flex;
+        flex-direction: row;
+        margin-bottom: 1.5rem;
+        margin-left: 0.6vw;
+    }
+
+    div#header {
+        aspect-ratio: 1/1;
+        background-image: url(https://trac.ffmpeg.org/ffmpeg-logo.png);
+        background-size: cover;
+        width: 1.6rem;
+    }
+
+    h1 {
+        font-size: 1.2rem;
+        margin: 0 0.5rem;
+    }
+
+    pre.mermaid {
+        align-items: center;
+        background-color: white;
+        box-shadow: 2px 2px 25px 0px #00000010;
+        color: transparent;
+        display: flex;
+        flex: 1;
+        justify-content: center;
+        margin: 0;
+        overflow: overlay;
+    }
+
+    pre.mermaid svg {
+        height: auto;
+        margin: 0;
+        max-width: unset !important;
+        width: auto;
+    }
+
+    pre.mermaid svg * {
+        user-select: none;
+    }
+</style>
+<div id="banner">
+    <div id="header"></div>
+    <h1>FFmpeg Execution Graph</h1>
+</div>
+<pre class="mermaid">
+__###__
+</pre>
+<script type="module">
+        import vanillaJsWheelZoom from 'https://cdn.jsdelivr.net/npm/vanilla-js-wheel-zoom@9.0.4/+esm';
+        import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+        function initViewer() {
+            var element = document.querySelector('.mermaid svg')
+            vanillaJsWheelZoom.create('pre.mermaid svg', { type: 'html', smoothTimeDrag: 0, width: element.clientWidth, height: element.clientHeight, maxScale: 3 });
+        }
+        mermaid.initialize({ startOnLoad: false }); 
+        document.fonts.ready.then(() => { mermaid.run({ querySelector: '.mermaid', postRenderCallback: initViewer }); });
+    </script>
+</body>
+</html>

--- a/fftools/resources/resman.c
+++ b/fftools/resources/resman.c
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2025 - softworkz
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file
+ * output writers for filtergraph details
+ */
+
+#include "config.h"
+
+#include <string.h>
+
+#if CONFIG_RESOURCE_COMPRESSION
+#include <zlib.h>
+#endif
+
+#include "resman.h"
+#include "fftools/ffmpeg_filter.h"
+#include "libavutil/avassert.h"
+#include "libavutil/pixdesc.h"
+#include "libavutil/dict.h"
+#include "libavutil/common.h"
+
+extern const unsigned char ff_graph_html_data[];
+extern const unsigned int ff_graph_html_len;
+
+extern const unsigned char ff_graph_css_data[];
+extern const unsigned ff_graph_css_len;
+
+static const FFResourceDefinition resource_definitions[] = {
+    [FF_RESOURCE_GRAPH_CSS]   = { FF_RESOURCE_GRAPH_CSS,   "graph.css",   &ff_graph_css_data[0],   &ff_graph_css_len   },
+    [FF_RESOURCE_GRAPH_HTML]  = { FF_RESOURCE_GRAPH_HTML,  "graph.html",  &ff_graph_html_data[0],  &ff_graph_html_len  },
+};
+
+
+static const AVClass resman_class = {
+    .class_name = "ResourceManager",
+};
+
+typedef struct ResourceManagerContext {
+    const AVClass *class;
+    AVDictionary *resource_dic;
+} ResourceManagerContext;
+
+static AVMutex mutex = AV_MUTEX_INITIALIZER;
+
+ResourceManagerContext *resman_ctx = NULL;
+
+
+#if CONFIG_RESOURCE_COMPRESSION
+
+static int decompress_gzip(ResourceManagerContext *ctx, uint8_t *in, unsigned in_len, char **out, size_t *out_len)
+{
+    z_stream strm;
+    unsigned chunk = 65534;
+    int ret;
+    uint8_t *buf;
+
+    *out = NULL;
+    memset(&strm, 0, sizeof(strm));
+
+    // Allocate output buffer with extra byte for null termination
+    buf = (uint8_t *)av_mallocz(chunk + 1);
+    if (!buf) {
+        av_log(ctx, AV_LOG_ERROR, "Failed to allocate decompression buffer\n");
+        return AVERROR(ENOMEM);
+    }
+
+    // 15 + 16 tells zlib to detect GZIP or zlib automatically
+    ret = inflateInit2(&strm, 15 + 16);
+    if (ret != Z_OK) {
+        av_log(ctx, AV_LOG_ERROR, "Error during zlib initialization: %s\n", strm.msg);
+        av_free(buf);
+        return AVERROR(ENOSYS);
+    }
+
+    strm.avail_in  = in_len;
+    strm.next_in   = in;
+    strm.avail_out = chunk;
+    strm.next_out  = buf;
+
+    ret = inflate(&strm, Z_FINISH);
+    if (ret != Z_OK && ret != Z_STREAM_END) {
+        av_log(ctx, AV_LOG_ERROR, "Inflate failed: %d, %s\n", ret, strm.msg);
+        inflateEnd(&strm);
+        av_free(buf);
+        return (ret == Z_STREAM_END) ? Z_OK : ((ret == Z_OK) ? Z_BUF_ERROR : ret);
+    }
+
+    if (strm.avail_out == 0) {
+        // TODO: Error or loop decoding?
+        av_log(ctx, AV_LOG_WARNING, "Decompression buffer may be too small\n");
+    }
+
+    *out_len = chunk - strm.avail_out;
+    buf[*out_len] = 0; // Ensure null termination
+
+    inflateEnd(&strm);
+    *out = (char *)buf;
+    return Z_OK;
+}
+#endif
+
+static ResourceManagerContext *get_resman_context(void)
+{
+    ResourceManagerContext *res = resman_ctx;
+
+    ff_mutex_lock(&mutex);
+
+    if (res)
+        goto end;
+
+    res = av_mallocz(sizeof(ResourceManagerContext));
+    if (!res) {
+        av_log(NULL, AV_LOG_ERROR, "Failed to allocate resource manager context\n");
+        goto end;
+    }
+
+    res->class = &resman_class;
+    resman_ctx = res;
+
+end:
+    ff_mutex_unlock(&mutex);
+    return res;
+}
+
+
+void ff_resman_uninit(void)
+{
+    ff_mutex_lock(&mutex);
+
+    if (resman_ctx) {
+        if (resman_ctx->resource_dic)
+            av_dict_free(&resman_ctx->resource_dic);
+        av_freep(&resman_ctx);
+    }
+
+    ff_mutex_unlock(&mutex);
+}
+
+
+char *ff_resman_get_string(FFResourceId resource_id)
+{
+    ResourceManagerContext *ctx               = get_resman_context();
+    FFResourceDefinition resource_definition = { 0 };
+    AVDictionaryEntry *dic_entry;
+    char *res = NULL;
+
+    if (!ctx)
+        return NULL;
+
+    for (unsigned i = 0; i < FF_ARRAY_ELEMS(resource_definitions); ++i) {
+        FFResourceDefinition def = resource_definitions[i];
+        if (def.resource_id == resource_id) {
+            resource_definition = def;
+            break;
+        }
+    }
+
+    if (!resource_definition.name) {
+        av_log(ctx, AV_LOG_ERROR, "Unable to find resource with ID %d\n", resource_id);
+        return NULL;
+    }
+
+    ff_mutex_lock(&mutex);
+
+    dic_entry = av_dict_get(ctx->resource_dic, resource_definition.name, NULL, 0);
+
+    if (!dic_entry) {
+        int dict_ret;
+
+#if CONFIG_RESOURCE_COMPRESSION
+
+        char *out = NULL;
+        size_t out_len;
+
+        int ret = decompress_gzip(ctx, (uint8_t *)resource_definition.data, *resource_definition.data_len, &out, &out_len);
+
+        if (ret) {
+            av_log(NULL, AV_LOG_ERROR, "Unable to decompress the resource with ID %d\n", resource_id);
+            goto end;
+        }
+
+        dict_ret = av_dict_set(&ctx->resource_dic, resource_definition.name, out, 0);
+        if (dict_ret < 0) {
+            av_log(NULL, AV_LOG_ERROR, "Failed to store decompressed resource in dictionary: %d\n", dict_ret);
+            av_freep(&out);
+            goto end;
+        }
+
+        av_freep(&out);
+#else
+
+        dict_ret = av_dict_set(&ctx->resource_dic, resource_definition.name, (const char *)resource_definition.data, 0);
+        if (dict_ret < 0) {
+            av_log(NULL, AV_LOG_ERROR, "Failed to store resource in dictionary: %d\n", dict_ret);
+            goto end;
+        }
+
+#endif
+        dic_entry = av_dict_get(ctx->resource_dic, resource_definition.name, NULL, 0);
+
+        if (!dic_entry) {
+            av_log(NULL, AV_LOG_ERROR, "Failed to retrieve resource from dictionary after storing it\n");
+            goto end;
+        }
+    }
+
+    res = dic_entry->value;
+
+end:
+    ff_mutex_unlock(&mutex);
+    return res;
+}

--- a/fftools/resources/resman.h
+++ b/fftools/resources/resman.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 - softworkz
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef FFTOOLS_RESOURCES_RESMAN_H
+#define FFTOOLS_RESOURCES_RESMAN_H
+
+#include <stdint.h>
+
+#include "config.h"
+#include "fftools/ffmpeg.h"
+#include "libavutil/avutil.h"
+#include "libavutil/bprint.h"
+#include "fftools/textformat/avtextformat.h"
+
+typedef enum {
+    FF_RESOURCE_GRAPH_CSS,
+    FF_RESOURCE_GRAPH_HTML,
+} FFResourceId;
+
+typedef struct FFResourceDefinition {
+    FFResourceId resource_id;
+    const char *name;
+
+    const unsigned char *data;
+    const unsigned *data_len;
+
+} FFResourceDefinition;
+
+void ff_resman_uninit(void);
+
+char *ff_resman_get_string(FFResourceId resource_id);
+
+#endif /* FFTOOLS_RESOURCES_RESMAN_H */

--- a/fftools/textformat/avtextformat.c
+++ b/fftools/textformat/avtextformat.c
@@ -507,7 +507,7 @@ void avtext_print_ts(AVTextFormatContext *tctx, const char *key, int64_t ts, int
         avtext_print_integer(tctx, key, ts);
 }
 
-void avtext_print_data(AVTextFormatContext *tctx, const char *name,
+void avtext_print_data(AVTextFormatContext *tctx, const char *key,
                        const uint8_t *data, int size)
 {
     AVBPrint bp;
@@ -532,11 +532,11 @@ void avtext_print_data(AVTextFormatContext *tctx, const char *name,
         data   += l;
         size   -= l;
     }
-    avtext_print_string(tctx, name, bp.str, 0);
+    avtext_print_string(tctx, key, bp.str, 0);
     av_bprint_finalize(&bp, NULL);
 }
 
-void avtext_print_data_hash(AVTextFormatContext *tctx, const char *name,
+void avtext_print_data_hash(AVTextFormatContext *tctx, const char *key,
                             const uint8_t *data, int size)
 {
     char buf[AV_HASH_MAX_SIZE * 2 + 64] = { 0 };
@@ -549,10 +549,10 @@ void avtext_print_data_hash(AVTextFormatContext *tctx, const char *name,
     av_hash_update(tctx->hash, data, size);
     len = snprintf(buf, sizeof(buf), "%s:", av_hash_get_name(tctx->hash));
     av_hash_final_hex(tctx->hash, (uint8_t *)&buf[len], (int)sizeof(buf) - len);
-    avtext_print_string(tctx, name, buf, 0);
+    avtext_print_string(tctx, key, buf, 0);
 }
 
-void avtext_print_integers(AVTextFormatContext *tctx, const char *name,
+void avtext_print_integers(AVTextFormatContext *tctx, const char *key,
                            uint8_t *data, int size, const char *format,
                            int columns, int bytes, int offset_add)
 {
@@ -560,7 +560,7 @@ void avtext_print_integers(AVTextFormatContext *tctx, const char *name,
     unsigned offset = 0;
     int l, i;
 
-    if (!name || !data || !format || columns <= 0 || bytes <= 0)
+    if (!key || !data || !format || columns <= 0 || bytes <= 0)
         return;
 
     av_bprint_init(&bp, 0, AV_BPRINT_SIZE_UNLIMITED);
@@ -578,7 +578,7 @@ void avtext_print_integers(AVTextFormatContext *tctx, const char *name,
         av_bprintf(&bp, "\n");
         offset += offset_add;
     }
-    avtext_print_string(tctx, name, bp.str, 0);
+    avtext_print_string(tctx, key, bp.str, 0);
     av_bprint_finalize(&bp, NULL);
 }
 

--- a/fftools/textformat/avtextformat.c
+++ b/fftools/textformat/avtextformat.c
@@ -311,24 +311,28 @@ void avtext_print_integer(AVTextFormatContext *tctx, const char *key, int64_t va
 
 static inline int validate_string(AVTextFormatContext *tctx, char **dstp, const char *src)
 {
-    const uint8_t *p, *endp;
+    const uint8_t *p, *endp, *srcp = (const uint8_t *)src;
     AVBPrint dstbuf;
+    AVBPrint invalid_seq;
     int invalid_chars_nb = 0, ret = 0;
 
+    *dstp = NULL;
     av_bprint_init(&dstbuf, 0, AV_BPRINT_SIZE_UNLIMITED);
+    av_bprint_init(&invalid_seq, 0, AV_BPRINT_SIZE_UNLIMITED);
 
-    endp = src + strlen(src);
-    for (p = src; *p;) {
-        uint32_t code;
+    endp = srcp + strlen(src);
+    for (p = srcp; *p;) {
+        int32_t code;
         int invalid = 0;
         const uint8_t *p0 = p;
 
         if (av_utf8_decode(&code, &p, endp, tctx->string_validation_utf8_flags) < 0) {
-            AVBPrint bp;
-            av_bprint_init(&bp, 0, AV_BPRINT_SIZE_AUTOMATIC);
-            bprint_bytes(&bp, p0, p-p0);
-            av_log(tctx, AV_LOG_DEBUG,
-                   "Invalid UTF-8 sequence %s found in string '%s'\n", bp.str, src);
+
+            av_bprint_clear(&invalid_seq);
+
+            bprint_bytes(&invalid_seq, p0, p - p0);
+
+            av_log(tctx, AV_LOG_DEBUG, "Invalid UTF-8 sequence '%s' found in string '%s'\n", invalid_seq.str, src);
             invalid = 1;
         }
 
@@ -358,6 +362,7 @@ static inline int validate_string(AVTextFormatContext *tctx, char **dstp, const 
 
 end:
     av_bprint_finalize(&dstbuf, dstp);
+    av_bprint_finalize(&invalid_seq, NULL);
     return ret;
 }
 

--- a/fftools/textformat/avtextformat.c
+++ b/fftools/textformat/avtextformat.c
@@ -34,9 +34,9 @@
 #include "libavutil/opt.h"
 #include "avtextformat.h"
 
-#define SECTION_ID_NONE -1
+#define SECTION_ID_NONE (-1)
 
-#define SHOW_OPTIONAL_FIELDS_AUTO       -1
+#define SHOW_OPTIONAL_FIELDS_AUTO      (-1)
 #define SHOW_OPTIONAL_FIELDS_NEVER       0
 #define SHOW_OPTIONAL_FIELDS_ALWAYS      1
 
@@ -64,14 +64,14 @@ static const char *textcontext_get_formatter_name(void *p)
 
 static const AVOption textcontext_options[] = {
     { "string_validation", "set string validation mode",
-      OFFSET(string_validation), AV_OPT_TYPE_INT, {.i64=AV_TEXTFORMAT_STRING_VALIDATION_REPLACE}, 0, AV_TEXTFORMAT_STRING_VALIDATION_NB-1, .unit = "sv" },
+      OFFSET(string_validation), AV_OPT_TYPE_INT, { .i64 = AV_TEXTFORMAT_STRING_VALIDATION_REPLACE }, 0, AV_TEXTFORMAT_STRING_VALIDATION_NB - 1, .unit = "sv" },
     { "sv", "set string validation mode",
-      OFFSET(string_validation), AV_OPT_TYPE_INT, {.i64=AV_TEXTFORMAT_STRING_VALIDATION_REPLACE}, 0, AV_TEXTFORMAT_STRING_VALIDATION_NB-1, .unit = "sv" },
-        { "ignore",  NULL, 0, AV_OPT_TYPE_CONST, {.i64 = AV_TEXTFORMAT_STRING_VALIDATION_IGNORE},  .unit = "sv" },
-        { "replace", NULL, 0, AV_OPT_TYPE_CONST, {.i64 = AV_TEXTFORMAT_STRING_VALIDATION_REPLACE}, .unit = "sv" },
-        { "fail",    NULL, 0, AV_OPT_TYPE_CONST, {.i64 = AV_TEXTFORMAT_STRING_VALIDATION_FAIL},    .unit = "sv" },
-    { "string_validation_replacement", "set string validation replacement string", OFFSET(string_validation_replacement), AV_OPT_TYPE_STRING, {.str=""}},
-    { "svr", "set string validation replacement string", OFFSET(string_validation_replacement), AV_OPT_TYPE_STRING, {.str="\xEF\xBF\xBD"}},
+      OFFSET(string_validation), AV_OPT_TYPE_INT, { .i64 = AV_TEXTFORMAT_STRING_VALIDATION_REPLACE }, 0, AV_TEXTFORMAT_STRING_VALIDATION_NB - 1, .unit = "sv" },
+        { "ignore",  NULL, 0, AV_OPT_TYPE_CONST,  { .i64 = AV_TEXTFORMAT_STRING_VALIDATION_IGNORE },  .unit = "sv" },
+        { "replace", NULL, 0, AV_OPT_TYPE_CONST,  { .i64 = AV_TEXTFORMAT_STRING_VALIDATION_REPLACE }, .unit = "sv" },
+        { "fail",    NULL, 0, AV_OPT_TYPE_CONST,  { .i64 = AV_TEXTFORMAT_STRING_VALIDATION_FAIL },    .unit = "sv" },
+    { "string_validation_replacement", "set string validation replacement string", OFFSET(string_validation_replacement), AV_OPT_TYPE_STRING, { .str = "" } },
+    { "svr", "set string validation replacement string", OFFSET(string_validation_replacement), AV_OPT_TYPE_STRING, { .str = "\xEF\xBF\xBD" } },
     { NULL }
 };
 
@@ -126,7 +126,7 @@ void avtext_context_close(AVTextFormatContext **ptctx)
 
 
 int avtext_context_open(AVTextFormatContext **ptctx, const AVTextFormatter *formatter, AVTextWriterContext *writer_context, const char *args,
-                        const struct AVTextFormatSection *sections, int nb_sections,
+                        const AVTextFormatSection *sections, int nb_sections,
                         int show_value_unit,
                         int use_value_prefix,
                         int use_byte_value_binary_prefix,
@@ -209,7 +209,7 @@ int avtext_context_open(AVTextFormatContext **ptctx, const AVTextFormatter *form
                     av_log(NULL, AV_LOG_ERROR, " %s", n);
                 av_log(NULL, AV_LOG_ERROR, "\n");
             }
-            return ret;
+            goto fail;
         }
     }
 
@@ -224,10 +224,10 @@ int avtext_context_open(AVTextFormatContext **ptctx, const AVTextFormatter *form
             if (ret < 0) {
                 AVBPrint bp;
                 av_bprint_init(&bp, 0, AV_BPRINT_SIZE_AUTOMATIC);
-                bprint_bytes(&bp, p0, p-p0),
-                    av_log(tctx, AV_LOG_ERROR,
-                           "Invalid UTF8 sequence %s found in string validation replace '%s'\n",
-                           bp.str, tctx->string_validation_replacement);
+                bprint_bytes(&bp, p0, p - p0);
+                av_log(tctx, AV_LOG_ERROR,
+                       "Invalid UTF8 sequence %s found in string validation replace '%s'\n",
+                       bp.str, tctx->string_validation_replacement);
                 return ret;
             }
         }
@@ -248,15 +248,13 @@ fail:
 }
 
 /* Temporary definitions during refactoring */
-static const char unit_second_str[]         = "s"    ;
-static const char unit_hertz_str[]          = "Hz"   ;
-static const char unit_byte_str[]           = "byte" ;
+static const char unit_second_str[]         = "s";
+static const char unit_hertz_str[]          = "Hz";
+static const char unit_byte_str[]           = "byte";
 static const char unit_bit_per_second_str[] = "bit/s";
 
 
-void avtext_print_section_header(AVTextFormatContext *tctx,
-                                               const void *data,
-                                               int section_id)
+void avtext_print_section_header(AVTextFormatContext *tctx, const void *data, int section_id)
 {
     tctx->level++;
     av_assert0(tctx->level < SECTION_MAX_NB_LEVELS);
@@ -273,7 +271,7 @@ void avtext_print_section_footer(AVTextFormatContext *tctx)
 {
     int section_id = tctx->section[tctx->level]->id;
     int parent_section_id = tctx->level ?
-        tctx->section[tctx->level-1]->id : SECTION_ID_NONE;
+        tctx->section[tctx->level - 1]->id : SECTION_ID_NONE;
 
     if (parent_section_id != SECTION_ID_NONE) {
         tctx->nb_item[tctx->level - 1]++;
@@ -285,8 +283,7 @@ void avtext_print_section_footer(AVTextFormatContext *tctx)
     tctx->level--;
 }
 
-void avtext_print_integer(AVTextFormatContext *tctx,
-                                        const char *key, int64_t val)
+void avtext_print_integer(AVTextFormatContext *tctx, const char *key, int64_t val)
 {
     const struct AVTextFormatSection *section = tctx->section[tctx->level];
 
@@ -324,11 +321,9 @@ static inline int validate_string(AVTextFormatContext *tctx, char **dstp, const 
 
             switch (tctx->string_validation) {
             case AV_TEXTFORMAT_STRING_VALIDATION_FAIL:
-                av_log(tctx, AV_LOG_ERROR,
-                       "Invalid UTF-8 sequence found in string '%s'\n", src);
+                av_log(tctx, AV_LOG_ERROR, "Invalid UTF-8 sequence found in string '%s'\n", src);
                 ret = AVERROR_INVALIDDATA;
                 goto end;
-                break;
 
             case AV_TEXTFORMAT_STRING_VALIDATION_REPLACE:
                 av_bprintf(&dstbuf, "%s", tctx->string_validation_replacement);
@@ -340,11 +335,10 @@ static inline int validate_string(AVTextFormatContext *tctx, char **dstp, const 
             av_bprint_append_data(&dstbuf, p0, p-p0);
     }
 
-    if (invalid_chars_nb && tctx->string_validation == AV_TEXTFORMAT_STRING_VALIDATION_REPLACE) {
+    if (invalid_chars_nb && tctx->string_validation == AV_TEXTFORMAT_STRING_VALIDATION_REPLACE)
         av_log(tctx, AV_LOG_WARNING,
                "%d invalid UTF-8 sequence(s) found in string '%s', replaced with '%s'\n",
                invalid_chars_nb, src, tctx->string_validation_replacement);
-    }
 
 end:
     av_bprint_finalize(&dstbuf, dstp);
@@ -352,7 +346,11 @@ end:
 }
 
 struct unit_value {
-    union { double d; int64_t i; } val;
+    union {
+        double  d;
+        int64_t i;
+    } val;
+
     const char *unit;
 };
 
@@ -402,8 +400,9 @@ static char *value_string(AVTextFormatContext *tctx, char *buf, int buf_size, st
             snprintf(buf, buf_size, "%f", vald);
         else
             snprintf(buf, buf_size, "%"PRId64, vali);
+
         av_strlcatf(buf, buf_size, "%s%s%s", *prefix_string || tctx->show_value_unit ? " " : "",
-                 prefix_string, tctx->show_value_unit ? uv.unit : "");
+                    prefix_string, tctx->show_value_unit ? uv.unit : "");
     }
 
     return buf;
@@ -427,8 +426,8 @@ int avtext_print_string(AVTextFormatContext *tctx, const char *key, const char *
 
     if (tctx->show_optional_fields == SHOW_OPTIONAL_FIELDS_NEVER ||
         (tctx->show_optional_fields == SHOW_OPTIONAL_FIELDS_AUTO
-        && (flags & AV_TEXTFORMAT_PRINT_STRING_OPTIONAL)
-        && !(tctx->formatter->flags & AV_TEXTFORMAT_FLAG_SUPPORTS_OPTIONAL_FIELDS)))
+            && (flags & AV_TEXTFORMAT_PRINT_STRING_OPTIONAL)
+            && !(tctx->formatter->flags & AV_TEXTFORMAT_FLAG_SUPPORTS_OPTIONAL_FIELDS)))
         return 0;
 
     if (section->show_all_entries || av_dict_get(section->entries_to_show, key, NULL, 0)) {
@@ -440,11 +439,10 @@ int avtext_print_string(AVTextFormatContext *tctx, const char *key, const char *
             if (ret < 0) goto end;
             tctx->formatter->print_string(tctx, key1, val1);
         end:
-            if (ret < 0) {
+            if (ret < 0)
                 av_log(tctx, AV_LOG_ERROR,
                        "Invalid key=value string combination %s=%s in section %s\n",
                        key, val, section->unique_name);
-            }
             av_free(key1);
             av_free(val1);
         } else {
@@ -457,8 +455,7 @@ int avtext_print_string(AVTextFormatContext *tctx, const char *key, const char *
     return ret;
 }
 
-void avtext_print_rational(AVTextFormatContext *tctx,
-                                         const char *key, AVRational q, char sep)
+void avtext_print_rational(AVTextFormatContext *tctx, const char *key, AVRational q, char sep)
 {
     char buf[44];
     snprintf(buf, sizeof(buf), "%d%c%d", q.num, sep, q.den);
@@ -466,7 +463,7 @@ void avtext_print_rational(AVTextFormatContext *tctx,
 }
 
 void avtext_print_time(AVTextFormatContext *tctx, const char *key,
-                              int64_t ts, const AVRational *time_base, int is_duration)
+                       int64_t ts, const AVRational *time_base, int is_duration)
 {
     char buf[128];
 
@@ -484,15 +481,14 @@ void avtext_print_time(AVTextFormatContext *tctx, const char *key,
 
 void avtext_print_ts(AVTextFormatContext *tctx, const char *key, int64_t ts, int is_duration)
 {
-    if ((!is_duration && ts == AV_NOPTS_VALUE) || (is_duration && ts == 0)) {
+    if ((!is_duration && ts == AV_NOPTS_VALUE) || (is_duration && ts == 0))
         avtext_print_string(tctx, key, "N/A", AV_TEXTFORMAT_PRINT_STRING_OPTIONAL);
-    } else {
+    else
         avtext_print_integer(tctx, key, ts);
-    }
 }
 
 void avtext_print_data(AVTextFormatContext *tctx, const char *name,
-                              const uint8_t *data, int size)
+                       const uint8_t *data, int size)
 {
     AVBPrint bp;
     int offset = 0, l, i;
@@ -520,12 +516,13 @@ void avtext_print_data(AVTextFormatContext *tctx, const char *name,
 }
 
 void avtext_print_data_hash(AVTextFormatContext *tctx, const char *name,
-                                   const uint8_t *data, int size)
+                            const uint8_t *data, int size)
 {
     char *p, buf[AV_HASH_MAX_SIZE * 2 + 64] = { 0 };
 
     if (!tctx->hash)
         return;
+
     av_hash_init(tctx->hash);
     av_hash_update(tctx->hash, data, size);
     snprintf(buf, sizeof(buf), "%s:", av_hash_get_name(tctx->hash));
@@ -551,7 +548,7 @@ void avtext_print_integers(AVTextFormatContext *tctx, const char *name,
             else if (bytes == 2) av_bprintf(&bp, format, AV_RN16(data));
             else if (bytes == 4) av_bprintf(&bp, format, AV_RN32(data));
             data += bytes;
-            size --;
+            size--;
         }
         av_bprintf(&bp, "\n");
         offset += offset_add;
@@ -641,7 +638,8 @@ fail:
     return ret;
 }
 
-static const AVTextFormatter *registered_formatters[7+1];
+static const AVTextFormatter *registered_formatters[7 + 1];
+
 static void formatters_register_all(void)
 {
     static int initialized;

--- a/fftools/textformat/avtextformat.c
+++ b/fftools/textformat/avtextformat.c
@@ -677,7 +677,7 @@ fail:
     return ret;
 }
 
-static const AVTextFormatter *registered_formatters[7 + 1];
+static const AVTextFormatter *registered_formatters[9 + 1];
 
 static void formatters_register_all(void)
 {
@@ -694,6 +694,8 @@ static void formatters_register_all(void)
     registered_formatters[4] = &avtextformatter_ini;
     registered_formatters[5] = &avtextformatter_json;
     registered_formatters[6] = &avtextformatter_xml;
+    registered_formatters[7] = &avtextformatter_mermaid;
+    registered_formatters[8] = &avtextformatter_mermaidhtml;
 }
 
 const AVTextFormatter *avtext_get_formatter_by_name(const char *name)

--- a/fftools/textformat/avtextformat.c
+++ b/fftools/textformat/avtextformat.c
@@ -125,13 +125,7 @@ void avtext_context_close(AVTextFormatContext **ptctx)
 
 
 int avtext_context_open(AVTextFormatContext **ptctx, const AVTextFormatter *formatter, AVTextWriterContext *writer_context, const char *args,
-                        const AVTextFormatSection *sections, int nb_sections,
-                        int show_value_unit,
-                        int use_value_prefix,
-                        int use_byte_value_binary_prefix,
-                        int use_value_sexagesimal_format,
-                        int show_optional_fields,
-                        char *show_data_hash)
+                        const AVTextFormatSection *sections, int nb_sections, AVTextFormatOptions options, char *show_data_hash)
 {
     AVTextFormatContext *tctx;
     int i, ret = 0;
@@ -154,11 +148,11 @@ int avtext_context_open(AVTextFormatContext **ptctx, const AVTextFormatter *form
         goto fail;
     }
 
-    tctx->show_value_unit = show_value_unit;
-    tctx->use_value_prefix = use_value_prefix;
-    tctx->use_byte_value_binary_prefix = use_byte_value_binary_prefix;
-    tctx->use_value_sexagesimal_format = use_value_sexagesimal_format;
-    tctx->show_optional_fields = show_optional_fields;
+    tctx->show_value_unit = options.show_value_unit;
+    tctx->use_value_prefix = options.use_value_prefix;
+    tctx->use_byte_value_binary_prefix = options.use_byte_value_binary_prefix;
+    tctx->use_value_sexagesimal_format = options.use_value_sexagesimal_format;
+    tctx->show_optional_fields = options.show_optional_fields;
 
     if (nb_sections > SECTION_MAX_NB_SECTIONS) {
         av_log(tctx, AV_LOG_ERROR, "The number of section definitions (%d) is larger than the maximum allowed (%d)\n", nb_sections, SECTION_MAX_NB_SECTIONS);

--- a/fftools/textformat/avtextformat.h
+++ b/fftools/textformat/avtextformat.h
@@ -148,11 +148,11 @@ void avtext_print_time(AVTextFormatContext *tctx, const char *key, int64_t ts, c
 
 void avtext_print_ts(AVTextFormatContext *tctx, const char *key, int64_t ts, int is_duration);
 
-void avtext_print_data(AVTextFormatContext *tctx, const char *name, const uint8_t *data, int size);
+void avtext_print_data(AVTextFormatContext *tctx, const char *key, const uint8_t *data, int size);
 
-void avtext_print_data_hash(AVTextFormatContext *tctx, const char *name, const uint8_t *data, int size);
+void avtext_print_data_hash(AVTextFormatContext *tctx, const char *key, const uint8_t *data, int size);
 
-void avtext_print_integers(AVTextFormatContext *tctx, const char *name, uint8_t *data, int size,
+void avtext_print_integers(AVTextFormatContext *tctx, const char *key, uint8_t *data, int size,
                            const char *format, int columns, int bytes, int offset_add);
 
 const AVTextFormatter *avtext_get_formatter_by_name(const char *name);

--- a/fftools/textformat/avtextformat.h
+++ b/fftools/textformat/avtextformat.h
@@ -31,6 +31,12 @@
 
 #define SECTION_MAX_NB_CHILDREN 11
 
+typedef struct AVTextFormatSectionContext {
+    char *context_id;
+    const char *context_type;
+    int context_flags;
+} AVTextFormatSectionContext;
+
 
 typedef struct AVTextFormatSection {
     int id;             ///< unique id identifying a section
@@ -42,6 +48,10 @@ typedef struct AVTextFormatSection {
                                            ///  For these sections the element_name field is mandatory.
 #define AV_TEXTFORMAT_SECTION_FLAG_HAS_TYPE        8 ///< the section contains a type to distinguish multiple nested elements
 #define AV_TEXTFORMAT_SECTION_FLAG_NUMBERING_BY_TYPE 16 ///< the items in this array section should be numbered individually by type
+#define AV_TEXTFORMAT_SECTION_FLAG_IS_SHAPE       32 ///< ...
+#define AV_TEXTFORMAT_SECTION_FLAG_HAS_LINKS      64 ///< ...
+#define AV_TEXTFORMAT_SECTION_PRINT_TAGS         128 ///< ...
+#define AV_TEXTFORMAT_SECTION_FLAG_IS_SUBGRAPH   256 ///< ...
 
     int flags;
     const int children_ids[SECTION_MAX_NB_CHILDREN + 1]; ///< list of children section IDS, terminated by -1
@@ -50,12 +60,17 @@ typedef struct AVTextFormatSection {
     AVDictionary *entries_to_show;
     const char *(*get_type)(const void *data); ///< function returning a type if defined, must be defined when SECTION_FLAG_HAS_TYPE is defined
     int show_all_entries;
+    const char *id_key;          ///< name of the key to be used as the id
+    const char *src_id_key;     ///< name of the key to be used as the source id for diagram connections
+    const char *dest_id_key;   ///< name of the key to be used as the target id for diagram connections
+    const char *linktype_key; ///< name of the key to be used as the link type for diagram connections (AVTextFormatLinkType)
 } AVTextFormatSection;
 
 typedef struct AVTextFormatContext AVTextFormatContext;
 
 #define AV_TEXTFORMAT_FLAG_SUPPORTS_OPTIONAL_FIELDS 1
 #define AV_TEXTFORMAT_FLAG_SUPPORTS_MIXED_ARRAY_CONTENT 2
+#define AV_TEXTFORMAT_FLAG_IS_DIAGRAM_FORMATTER         4
 
 typedef enum {
     AV_TEXTFORMAT_STRING_VALIDATION_FAIL,
@@ -63,6 +78,18 @@ typedef enum {
     AV_TEXTFORMAT_STRING_VALIDATION_IGNORE,
     AV_TEXTFORMAT_STRING_VALIDATION_NB
 } StringValidation;
+
+typedef enum {
+    AV_TEXTFORMAT_LINKTYPE_SRCDEST,
+    AV_TEXTFORMAT_LINKTYPE_DESTSRC,
+    AV_TEXTFORMAT_LINKTYPE_BIDIR,
+    AV_TEXTFORMAT_LINKTYPE_NONDIR,
+    AV_TEXTFORMAT_LINKTYPE_HIDDEN,
+    AV_TEXTFORMAT_LINKTYPE_ONETOMANY = AV_TEXTFORMAT_LINKTYPE_SRCDEST,
+    AV_TEXTFORMAT_LINKTYPE_MANYTOONE = AV_TEXTFORMAT_LINKTYPE_DESTSRC,
+    AV_TEXTFORMAT_LINKTYPE_ONETOONE = AV_TEXTFORMAT_LINKTYPE_BIDIR,
+    AV_TEXTFORMAT_LINKTYPE_MANYTOMANY = AV_TEXTFORMAT_LINKTYPE_NONDIR,
+} AVTextFormatLinkType;
 
 typedef struct AVTextFormatter {
     const AVClass *priv_class;      ///< private class of the formatter, if any
@@ -166,5 +193,7 @@ extern const AVTextFormatter avtextformatter_flat;
 extern const AVTextFormatter avtextformatter_ini;
 extern const AVTextFormatter avtextformatter_json;
 extern const AVTextFormatter avtextformatter_xml;
+extern const AVTextFormatter avtextformatter_mermaid;
+extern const AVTextFormatter avtextformatter_mermaidhtml;
 
 #endif /* FFTOOLS_TEXTFORMAT_AVTEXTFORMAT_H */

--- a/fftools/textformat/avtextformat.h
+++ b/fftools/textformat/avtextformat.h
@@ -21,9 +21,7 @@
 #ifndef FFTOOLS_TEXTFORMAT_AVTEXTFORMAT_H
 #define FFTOOLS_TEXTFORMAT_AVTEXTFORMAT_H
 
-#include <stddef.h>
 #include <stdint.h>
-#include "libavutil/attributes.h"
 #include "libavutil/dict.h"
 #include "libavformat/avio.h"
 #include "libavutil/bprint.h"
@@ -103,7 +101,7 @@ struct AVTextFormatContext {
     unsigned int nb_item_type[SECTION_MAX_NB_LEVELS][SECTION_MAX_NB_SECTIONS];
 
     /** section per each level */
-    const struct AVTextFormatSection *section[SECTION_MAX_NB_LEVELS];
+    const AVTextFormatSection *section[SECTION_MAX_NB_LEVELS];
     AVBPrint section_pbuf[SECTION_MAX_NB_LEVELS]; ///< generic print buffer dedicated to each section,
                                                   ///  used by various formatters
 
@@ -124,7 +122,7 @@ struct AVTextFormatContext {
 #define AV_TEXTFORMAT_PRINT_STRING_VALIDATE 2
 
 int avtext_context_open(AVTextFormatContext **ptctx, const AVTextFormatter *formatter, AVTextWriterContext *writer_context, const char *args,
-                        const struct AVTextFormatSection *sections, int nb_sections,
+                        const AVTextFormatSection *sections, int nb_sections,
                         int show_value_unit,
                         int use_value_prefix,
                         int use_byte_value_binary_prefix,

--- a/fftools/textformat/avtextformat.h
+++ b/fftools/textformat/avtextformat.h
@@ -75,7 +75,6 @@ typedef struct AVTextFormatter {
     void (*print_section_header)(AVTextFormatContext *tctx, const void *data);
     void (*print_section_footer)(AVTextFormatContext *tctx);
     void (*print_integer)       (AVTextFormatContext *tctx, const char *, int64_t);
-    void (*print_rational)      (AVTextFormatContext *tctx, AVRational *q, char *sep);
     void (*print_string)        (AVTextFormatContext *tctx, const char *, const char *);
     int flags;                  ///< a combination or AV_TEXTFORMAT__FLAG_*
 } AVTextFormatter;

--- a/fftools/textformat/avtextformat.h
+++ b/fftools/textformat/avtextformat.h
@@ -46,11 +46,11 @@ typedef struct AVTextFormatSection {
 #define AV_TEXTFORMAT_SECTION_FLAG_NUMBERING_BY_TYPE 16 ///< the items in this array section should be numbered individually by type
 
     int flags;
-    const int children_ids[SECTION_MAX_NB_CHILDREN+1]; ///< list of children section IDS, terminated by -1
+    const int children_ids[SECTION_MAX_NB_CHILDREN + 1]; ///< list of children section IDS, terminated by -1
     const char *element_name; ///< name of the contained element, if provided
     const char *unique_name;  ///< unique section name, in case the name is ambiguous
     AVDictionary *entries_to_show;
-    const char *(* get_type)(const void *data); ///< function returning a type if defined, must be defined when SECTION_FLAG_HAS_TYPE is defined
+    const char *(*get_type)(const void *data); ///< function returning a type if defined, must be defined when SECTION_FLAG_HAS_TYPE is defined
     int show_all_entries;
 } AVTextFormatSection;
 
@@ -86,17 +86,17 @@ typedef struct AVTextFormatter {
 #define SECTION_MAX_NB_SECTIONS 100
 
 struct AVTextFormatContext {
-    const AVClass *class;           ///< class of the formatter
-    const AVTextFormatter *formatter;           ///< the AVTextFormatter of which this is an instance
-    AVTextWriterContext *writer;           ///< the AVTextWriterContext
+    const AVClass *class;              ///< class of the formatter
+    const AVTextFormatter *formatter;  ///< the AVTextFormatter of which this is an instance
+    AVTextWriterContext *writer;       ///< the AVTextWriterContext
 
-    char *name;                     ///< name of this formatter instance
-    void *priv;                     ///< private data for use by the filter
+    char *name;                        ///< name of this formatter instance
+    void *priv;                        ///< private data for use by the filter
 
-    const struct AVTextFormatSection *sections; ///< array containing all sections
-    int nb_sections;                ///< number of sections
+    const AVTextFormatSection *sections; ///< array containing all sections
+    int nb_sections;                   ///< number of sections
 
-    int level;                      ///< current level, starting from 0
+    int level;                         ///< current level, starting from 0
 
     /** number of the item printed in the given section, starting from 0 */
     unsigned int nb_item[SECTION_MAX_NB_LEVELS];

--- a/fftools/textformat/avtextformat.h
+++ b/fftools/textformat/avtextformat.h
@@ -117,17 +117,19 @@ struct AVTextFormatContext {
     unsigned int string_validation_utf8_flags;
 };
 
+typedef struct AVTextFormatOptions {
+    int show_optional_fields;
+    int show_value_unit;
+    int use_value_prefix;
+    int use_byte_value_binary_prefix;
+    int use_value_sexagesimal_format;
+} AVTextFormatOptions;
+
 #define AV_TEXTFORMAT_PRINT_STRING_OPTIONAL 1
 #define AV_TEXTFORMAT_PRINT_STRING_VALIDATE 2
 
 int avtext_context_open(AVTextFormatContext **ptctx, const AVTextFormatter *formatter, AVTextWriterContext *writer_context, const char *args,
-                        const AVTextFormatSection *sections, int nb_sections,
-                        int show_value_unit,
-                        int use_value_prefix,
-                        int use_byte_value_binary_prefix,
-                        int use_value_sexagesimal_format,
-                        int show_optional_fields,
-                        char *show_data_hash);
+                        const AVTextFormatSection *sections, int nb_sections, AVTextFormatOptions options, char *show_data_hash);
 
 void avtext_context_close(AVTextFormatContext **tctx);
 

--- a/fftools/textformat/avtextformat.h
+++ b/fftools/textformat/avtextformat.h
@@ -138,7 +138,7 @@ void avtext_print_section_header(AVTextFormatContext *tctx, const void *data, in
 
 void avtext_print_section_footer(AVTextFormatContext *tctx);
 
-void avtext_print_integer(AVTextFormatContext *tctx, const char *key, int64_t val);
+void avtext_print_integer(AVTextFormatContext *tctx, const char *key, int64_t val, int flags);
 
 int avtext_print_string(AVTextFormatContext *tctx, const char *key, const char *val, int flags);
 

--- a/fftools/textformat/avtextwriters.h
+++ b/fftools/textformat/avtextwriters.h
@@ -21,14 +21,9 @@
 #ifndef FFTOOLS_TEXTFORMAT_AVTEXTWRITERS_H
 #define FFTOOLS_TEXTFORMAT_AVTEXTWRITERS_H
 
-#include <stddef.h>
 #include <stdint.h>
-#include "libavutil/attributes.h"
-#include "libavutil/dict.h"
 #include "libavformat/avio.h"
 #include "libavutil/bprint.h"
-#include "libavutil/rational.h"
-#include "libavutil/hash.h"
 
 typedef struct AVTextWriterContext AVTextWriterContext;
 

--- a/fftools/textformat/avtextwriters.h
+++ b/fftools/textformat/avtextwriters.h
@@ -37,11 +37,11 @@ typedef struct AVTextWriter {
     int priv_size;                  ///< private size for the writer private class
     const char *name;
 
-    int (* init)(AVTextWriterContext *wctx);
-    void (* uninit)(AVTextWriterContext *wctx);
-    void (* writer_w8)(AVTextWriterContext *wctx, int b);
-    void (* writer_put_str)(AVTextWriterContext *wctx, const char *str);
-    void (* writer_printf)(AVTextWriterContext *wctx, const char *fmt, ...);
+    int (*init)(AVTextWriterContext *wctx);
+    void (*uninit)(AVTextWriterContext *wctx);
+    void (*writer_w8)(AVTextWriterContext *wctx, int b);
+    void (*writer_put_str)(AVTextWriterContext *wctx, const char *str);
+    void (*writer_printf)(AVTextWriterContext *wctx, const char *fmt, ...);
 } AVTextWriter;
 
 typedef struct AVTextWriterContext {
@@ -49,7 +49,6 @@ typedef struct AVTextWriterContext {
     const AVTextWriter *writer;
     const char *name;
     void *priv;                     ///< private data for use by the writer
-
 } AVTextWriterContext;
 
 

--- a/fftools/textformat/avtextwriters.h
+++ b/fftools/textformat/avtextwriters.h
@@ -36,7 +36,7 @@ typedef struct AVTextWriter {
     void (*uninit)(AVTextWriterContext *wctx);
     void (*writer_w8)(AVTextWriterContext *wctx, int b);
     void (*writer_put_str)(AVTextWriterContext *wctx, const char *str);
-    void (*writer_printf)(AVTextWriterContext *wctx, const char *fmt, ...);
+    void (*writer_vprintf)(AVTextWriterContext *wctx, const char *fmt, va_list vl);
 } AVTextWriter;
 
 typedef struct AVTextWriterContext {

--- a/fftools/textformat/tf_compact.c
+++ b/fftools/textformat/tf_compact.c
@@ -58,10 +58,10 @@ static const char *c_escape_str(AVBPrint *dst, const char *src, const char sep, 
 
     for (p = src; *p; p++) {
         switch (*p) {
-        case '\b': av_bprintf(dst, "%s", "\\b");  break;
-        case '\f': av_bprintf(dst, "%s", "\\f");  break;
-        case '\n': av_bprintf(dst, "%s", "\\n");  break;
-        case '\r': av_bprintf(dst, "%s", "\\r");  break;
+        case '\b': av_bprintf(dst, "%s", "\\b"); break;
+        case '\f': av_bprintf(dst, "%s", "\\f"); break;
+        case '\n': av_bprintf(dst, "%s", "\\n"); break;
+        case '\r': av_bprintf(dst, "%s", "\\r"); break;
         case '\\': av_bprintf(dst, "%s", "\\\\"); break;
         default:
             if (*p == sep)
@@ -78,6 +78,7 @@ static const char *c_escape_str(AVBPrint *dst, const char *src, const char sep, 
 static const char *csv_escape_str(AVBPrint *dst, const char *src, const char sep, void *log_ctx)
 {
     char meta_chars[] = { sep, '"', '\n', '\r', '\0' };
+
     int needs_quoting = !!src[strcspn(src, meta_chars)];
 
     if (needs_quoting)
@@ -114,16 +115,16 @@ typedef struct CompactContext {
 #undef OFFSET
 #define OFFSET(x) offsetof(CompactContext, x)
 
-static const AVOption compact_options[]= {
-    {"item_sep", "set item separator",    OFFSET(item_sep_str),    AV_OPT_TYPE_STRING, {.str="|"},  0, 0 },
-    {"s",        "set item separator",    OFFSET(item_sep_str),    AV_OPT_TYPE_STRING, {.str="|"},  0, 0 },
-    {"nokey",    "force no key printing", OFFSET(nokey),           AV_OPT_TYPE_BOOL,   {.i64=0},    0,        1        },
-    {"nk",       "force no key printing", OFFSET(nokey),           AV_OPT_TYPE_BOOL,   {.i64=0},    0,        1        },
-    {"escape",   "set escape mode",       OFFSET(escape_mode_str), AV_OPT_TYPE_STRING, {.str="c"},  0, 0 },
-    {"e",        "set escape mode",       OFFSET(escape_mode_str), AV_OPT_TYPE_STRING, {.str="c"},  0, 0 },
-    {"print_section", "print section name", OFFSET(print_section), AV_OPT_TYPE_BOOL,   {.i64=1},    0,        1        },
-    {"p",             "print section name", OFFSET(print_section), AV_OPT_TYPE_BOOL,   {.i64=1},    0,        1        },
-    {NULL},
+static const AVOption compact_options[] = {
+    { "item_sep", "set item separator",      OFFSET(item_sep_str),    AV_OPT_TYPE_STRING, { .str = "|" },  0, 0 },
+    { "s",        "set item separator",      OFFSET(item_sep_str),    AV_OPT_TYPE_STRING, { .str = "|" },  0, 0 },
+    { "nokey",    "force no key printing",   OFFSET(nokey),           AV_OPT_TYPE_BOOL,   { .i64 = 0   },  0, 1 },
+    { "nk",       "force no key printing",   OFFSET(nokey),           AV_OPT_TYPE_BOOL,   { .i64 = 0   },  0, 1 },
+    { "escape",   "set escape mode",         OFFSET(escape_mode_str), AV_OPT_TYPE_STRING, { .str = "c" },  0, 0 },
+    { "e",        "set escape mode",         OFFSET(escape_mode_str), AV_OPT_TYPE_STRING, { .str = "c" },  0, 0 },
+    { "print_section", "print section name", OFFSET(print_section),   AV_OPT_TYPE_BOOL,   { .i64 = 1   },  0, 1 },
+    { "p",             "print section name", OFFSET(print_section),   AV_OPT_TYPE_BOOL,   { .i64 = 1   },  0, 1 },
+    { NULL },
 };
 
 DEFINE_FORMATTER_CLASS(compact);
@@ -139,10 +140,13 @@ static av_cold int compact_init(AVTextFormatContext *wctx)
     }
     compact->item_sep = compact->item_sep_str[0];
 
-    if      (!strcmp(compact->escape_mode_str, "none")) compact->escape_str = none_escape_str;
-    else if (!strcmp(compact->escape_mode_str, "c"   )) compact->escape_str = c_escape_str;
-    else if (!strcmp(compact->escape_mode_str, "csv" )) compact->escape_str = csv_escape_str;
-    else {
+    if        (!strcmp(compact->escape_mode_str, "none")) {
+        compact->escape_str = none_escape_str;
+    } else if (!strcmp(compact->escape_mode_str, "c"   )) {
+        compact->escape_str = c_escape_str;
+    } else if (!strcmp(compact->escape_mode_str, "csv" )) {
+        compact->escape_str = csv_escape_str;
+    } else {
         av_log(wctx, AV_LOG_ERROR, "Unknown escape mode '%s'\n", compact->escape_mode_str);
         return AVERROR(EINVAL);
     }
@@ -162,8 +166,8 @@ static void compact_print_section_header(AVTextFormatContext *wctx, const void *
     av_bprint_clear(&wctx->section_pbuf[wctx->level]);
     if (parent_section &&
         (section->flags & AV_TEXTFORMAT_SECTION_FLAG_HAS_TYPE ||
-         (!(section->flags & AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY) &&
-          !(parent_section->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER|AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY))))) {
+            (!(section->flags & AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY) &&
+                !(parent_section->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER | AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY))))) {
 
         /* define a prefix for elements not contained in an array or
            in a wrapper, or for array elements with a type */
@@ -171,10 +175,10 @@ static void compact_print_section_header(AVTextFormatContext *wctx, const void *
         AVBPrint *section_pbuf = &wctx->section_pbuf[wctx->level];
 
         compact->nested_section[wctx->level] = 1;
-        compact->has_nested_elems[wctx->level-1] = 1;
+        compact->has_nested_elems[wctx->level - 1] = 1;
 
         av_bprintf(section_pbuf, "%s%s",
-                   wctx->section_pbuf[wctx->level-1].str, element_name);
+                   wctx->section_pbuf[wctx->level - 1].str, element_name);
 
         if (section->flags & AV_TEXTFORMAT_SECTION_FLAG_HAS_TYPE) {
             // add /TYPE to prefix
@@ -191,24 +195,25 @@ static void compact_print_section_header(AVTextFormatContext *wctx, const void *
         }
         av_bprint_chars(section_pbuf, ':', 1);
 
-        wctx->nb_item[wctx->level] = wctx->nb_item[wctx->level-1];
+        wctx->nb_item[wctx->level] = wctx->nb_item[wctx->level - 1];
     } else {
-        if (parent_section && !(parent_section->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER|AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY)) &&
-            wctx->level && wctx->nb_item[wctx->level-1])
+        if (parent_section && !(parent_section->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER | AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY)) &&
+            wctx->level && wctx->nb_item[wctx->level - 1])
             writer_w8(wctx, compact->item_sep);
         if (compact->print_section &&
-            !(section->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER|AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY)))
+            !(section->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER | AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY)))
             writer_printf(wctx, "%s%c", section->name, compact->item_sep);
     }
 }
 
 static void compact_print_section_footer(AVTextFormatContext *wctx)
 {
+    const struct AVTextFormatSection *section = wctx->section[wctx->level];
     CompactContext *compact = wctx->priv;
 
     if (!compact->nested_section[wctx->level] &&
         compact->terminate_line[wctx->level] &&
-        !(wctx->section[wctx->level]->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER|AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY)))
+        !(section->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER | AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY)))
         writer_w8(wctx, '\n');
 }
 
@@ -217,9 +222,12 @@ static void compact_print_str(AVTextFormatContext *wctx, const char *key, const 
     CompactContext *compact = wctx->priv;
     AVBPrint buf;
 
-    if (wctx->nb_item[wctx->level]) writer_w8(wctx, compact->item_sep);
+    if (wctx->nb_item[wctx->level])
+        writer_w8(wctx, compact->item_sep);
+
     if (!compact->nokey)
         writer_printf(wctx, "%s%s=", wctx->section_pbuf[wctx->level].str, key);
+
     av_bprint_init(&buf, 1, AV_BPRINT_SIZE_UNLIMITED);
     writer_put_str(wctx, compact->escape_str(&buf, value, compact->item_sep, wctx));
     av_bprint_finalize(&buf, NULL);
@@ -229,9 +237,12 @@ static void compact_print_int(AVTextFormatContext *wctx, const char *key, int64_
 {
     CompactContext *compact = wctx->priv;
 
-    if (wctx->nb_item[wctx->level]) writer_w8(wctx, compact->item_sep);
+    if (wctx->nb_item[wctx->level])
+        writer_w8(wctx, compact->item_sep);
+
     if (!compact->nokey)
         writer_printf(wctx, "%s%s=", wctx->section_pbuf[wctx->level].str, key);
+
     writer_printf(wctx, "%"PRId64, value);
 }
 
@@ -253,15 +264,15 @@ const AVTextFormatter avtextformatter_compact = {
 #define OFFSET(x) offsetof(CompactContext, x)
 
 static const AVOption csv_options[] = {
-    {"item_sep", "set item separator",    OFFSET(item_sep_str),    AV_OPT_TYPE_STRING, {.str=","},  0, 0 },
-    {"s",        "set item separator",    OFFSET(item_sep_str),    AV_OPT_TYPE_STRING, {.str=","},  0, 0 },
-    {"nokey",    "force no key printing", OFFSET(nokey),           AV_OPT_TYPE_BOOL,   {.i64=1},    0,        1        },
-    {"nk",       "force no key printing", OFFSET(nokey),           AV_OPT_TYPE_BOOL,   {.i64=1},    0,        1        },
-    {"escape",   "set escape mode",       OFFSET(escape_mode_str), AV_OPT_TYPE_STRING, {.str="csv"}, 0, 0 },
-    {"e",        "set escape mode",       OFFSET(escape_mode_str), AV_OPT_TYPE_STRING, {.str="csv"}, 0, 0 },
-    {"print_section", "print section name", OFFSET(print_section), AV_OPT_TYPE_BOOL,   {.i64=1},    0,        1        },
-    {"p",             "print section name", OFFSET(print_section), AV_OPT_TYPE_BOOL,   {.i64=1},    0,        1        },
-    {NULL},
+    { "item_sep", "set item separator",      OFFSET(item_sep_str),    AV_OPT_TYPE_STRING, { .str = ","   }, 0, 0 },
+    { "s",        "set item separator",      OFFSET(item_sep_str),    AV_OPT_TYPE_STRING, { .str = ","   }, 0, 0 },
+    { "nokey",    "force no key printing",   OFFSET(nokey),           AV_OPT_TYPE_BOOL,   { .i64 = 1     }, 0, 1 },
+    { "nk",       "force no key printing",   OFFSET(nokey),           AV_OPT_TYPE_BOOL,   { .i64 = 1     }, 0, 1 },
+    { "escape",   "set escape mode",         OFFSET(escape_mode_str), AV_OPT_TYPE_STRING, { .str = "csv" }, 0, 0 },
+    { "e",        "set escape mode",         OFFSET(escape_mode_str), AV_OPT_TYPE_STRING, { .str = "csv" }, 0, 0 },
+    { "print_section", "print section name", OFFSET(print_section),   AV_OPT_TYPE_BOOL,   { .i64 = 1     }, 0, 1 },
+    { "p",             "print section name", OFFSET(print_section),   AV_OPT_TYPE_BOOL,   { .i64 = 1     }, 0, 1 },
+    { NULL },
 };
 
 DEFINE_FORMATTER_CLASS(csv);

--- a/fftools/textformat/tf_compact.c
+++ b/fftools/textformat/tf_compact.c
@@ -28,23 +28,7 @@
 #include "libavutil/bprint.h"
 #include "libavutil/error.h"
 #include "libavutil/opt.h"
-
-
-#define writer_w8(wctx_, b_) (wctx_)->writer->writer->writer_w8((wctx_)->writer, b_)
-#define writer_put_str(wctx_, str_) (wctx_)->writer->writer->writer_put_str((wctx_)->writer, str_)
-#define writer_printf(wctx_, fmt_, ...) (wctx_)->writer->writer->writer_printf((wctx_)->writer, fmt_, __VA_ARGS__)
-
-
-#define DEFINE_FORMATTER_CLASS(name)                   \
-static const char *name##_get_name(void *ctx)       \
-{                                                   \
-    return #name ;                                  \
-}                                                   \
-static const AVClass name##_class = {               \
-    .class_name = #name,                            \
-    .item_name  = name##_get_name,                  \
-    .option     = name##_options                    \
-}
+#include "tf_internal.h"
 
 
 /* Compact output */
@@ -157,9 +141,12 @@ static av_cold int compact_init(AVTextFormatContext *wctx)
 static void compact_print_section_header(AVTextFormatContext *wctx, const void *data)
 {
     CompactContext *compact = wctx->priv;
-    const struct AVTextFormatSection *section = wctx->section[wctx->level];
-    const struct AVTextFormatSection *parent_section = wctx->level ?
-        wctx->section[wctx->level-1] : NULL;
+    const AVTextFormatSection *section = tf_get_section(wctx, wctx->level);
+    const AVTextFormatSection *parent_section = tf_get_parent_section(wctx, wctx->level);
+
+    if (!section)
+        return;
+
     compact->terminate_line[wctx->level] = 1;
     compact->has_nested_elems[wctx->level] = 0;
 
@@ -208,8 +195,11 @@ static void compact_print_section_header(AVTextFormatContext *wctx, const void *
 
 static void compact_print_section_footer(AVTextFormatContext *wctx)
 {
-    const struct AVTextFormatSection *section = wctx->section[wctx->level];
     CompactContext *compact = wctx->priv;
+    const AVTextFormatSection *section = tf_get_section(wctx, wctx->level);
+
+    if (!section)
+        return;
 
     if (!compact->nested_section[wctx->level] &&
         compact->terminate_line[wctx->level] &&

--- a/fftools/textformat/tf_default.c
+++ b/fftools/textformat/tf_default.c
@@ -56,11 +56,11 @@ typedef struct DefaultContext {
 #define OFFSET(x) offsetof(DefaultContext, x)
 
 static const AVOption default_options[] = {
-    { "noprint_wrappers", "do not print headers and footers", OFFSET(noprint_wrappers), AV_OPT_TYPE_BOOL, {.i64=0}, 0, 1 },
-    { "nw",               "do not print headers and footers", OFFSET(noprint_wrappers), AV_OPT_TYPE_BOOL, {.i64=0}, 0, 1 },
-    { "nokey",          "force no key printing",     OFFSET(nokey),          AV_OPT_TYPE_BOOL, {.i64=0}, 0, 1 },
-    { "nk",             "force no key printing",     OFFSET(nokey),          AV_OPT_TYPE_BOOL, {.i64=0}, 0, 1 },
-    {NULL},
+    { "noprint_wrappers", "do not print headers and footers", OFFSET(noprint_wrappers), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1 },
+    { "nw",               "do not print headers and footers", OFFSET(noprint_wrappers), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1 },
+    { "nokey",            "force no key printing",            OFFSET(nokey),            AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1 },
+    { "nk",               "force no key printing",            OFFSET(nokey),            AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1 },
+    { NULL },
 };
 
 DEFINE_FORMATTER_CLASS(default);
@@ -69,7 +69,7 @@ DEFINE_FORMATTER_CLASS(default);
 static inline char *upcase_string(char *dst, size_t dst_size, const char *src)
 {
     int i;
-    for (i = 0; src[i] && i < dst_size-1; i++)
+    for (i = 0; src[i] && i < dst_size - 1; i++)
         dst[i] = av_toupper(src[i]);
     dst[i] = 0;
     return dst;
@@ -85,10 +85,10 @@ static void default_print_section_header(AVTextFormatContext *wctx, const void *
 
     av_bprint_clear(&wctx->section_pbuf[wctx->level]);
     if (parent_section &&
-        !(parent_section->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER|AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY))) {
+        !(parent_section->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER | AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY))) {
         def->nested_section[wctx->level] = 1;
         av_bprintf(&wctx->section_pbuf[wctx->level], "%s%s:",
-                   wctx->section_pbuf[wctx->level-1].str,
+                   wctx->section_pbuf[wctx->level - 1].str,
                    upcase_string(buf, sizeof(buf),
                                  av_x_if_null(section->element_name, section->name)));
     }
@@ -96,7 +96,7 @@ static void default_print_section_header(AVTextFormatContext *wctx, const void *
     if (def->noprint_wrappers || def->nested_section[wctx->level])
         return;
 
-    if (!(section->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER|AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY)))
+    if (!(section->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER | AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY)))
         writer_printf(wctx, "[%s]\n", upcase_string(buf, sizeof(buf), section->name));
 }
 
@@ -109,7 +109,7 @@ static void default_print_section_footer(AVTextFormatContext *wctx)
     if (def->noprint_wrappers || def->nested_section[wctx->level])
         return;
 
-    if (!(section->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER|AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY)))
+    if (!(section->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER | AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY)))
         writer_printf(wctx, "[/%s]\n", upcase_string(buf, sizeof(buf), section->name));
 }
 

--- a/fftools/textformat/tf_default.c
+++ b/fftools/textformat/tf_default.c
@@ -68,9 +68,10 @@ DEFINE_FORMATTER_CLASS(default);
 /* lame uppercasing routine, assumes the string is lower case ASCII */
 static inline char *upcase_string(char *dst, size_t dst_size, const char *src)
 {
-    int i;
+    unsigned i;
+
     for (i = 0; src[i] && i < dst_size - 1; i++)
-        dst[i] = av_toupper(src[i]);
+        dst[i] = (char)av_toupper(src[i]);
     dst[i] = 0;
     return dst;
 }
@@ -105,6 +106,9 @@ static void default_print_section_footer(AVTextFormatContext *wctx)
     DefaultContext *def = wctx->priv;
     const struct AVTextFormatSection *section = wctx->section[wctx->level];
     char buf[32];
+
+    if (!section)
+        return;
 
     if (def->noprint_wrappers || def->nested_section[wctx->level])
         return;

--- a/fftools/textformat/tf_flat.c
+++ b/fftools/textformat/tf_flat.c
@@ -28,22 +28,7 @@
 #include "libavutil/bprint.h"
 #include "libavutil/error.h"
 #include "libavutil/opt.h"
-
-#define writer_w8(wctx_, b_) (wctx_)->writer->writer->writer_w8((wctx_)->writer, b_)
-#define writer_put_str(wctx_, str_) (wctx_)->writer->writer->writer_put_str((wctx_)->writer, str_)
-#define writer_printf(wctx_, fmt_, ...) (wctx_)->writer->writer->writer_printf((wctx_)->writer, fmt_, __VA_ARGS__)
-
-#define DEFINE_FORMATTER_CLASS(name)                   \
-static const char *name##_get_name(void *ctx)       \
-{                                                   \
-    return #name ;                                  \
-}                                                   \
-static const AVClass name##_class = {               \
-    .class_name = #name,                            \
-    .item_name  = name##_get_name,                  \
-    .option     = name##_options                    \
-}
-
+#include "tf_internal.h"
 
 /* Flat output */
 
@@ -118,9 +103,11 @@ static void flat_print_section_header(AVTextFormatContext *wctx, const void *dat
 {
     FlatContext *flat = wctx->priv;
     AVBPrint *buf = &wctx->section_pbuf[wctx->level];
-    const struct AVTextFormatSection *section = wctx->section[wctx->level];
-    const struct AVTextFormatSection *parent_section = wctx->level ?
-        wctx->section[wctx->level-1] : NULL;
+    const AVTextFormatSection *section = tf_get_section(wctx, wctx->level);
+    const AVTextFormatSection *parent_section = tf_get_parent_section(wctx, wctx->level);
+
+    if (!section)
+        return;
 
     /* build section header */
     av_bprint_clear(buf);

--- a/fftools/textformat/tf_flat.c
+++ b/fftools/textformat/tf_flat.c
@@ -57,12 +57,12 @@ typedef struct FlatContext {
 #undef OFFSET
 #define OFFSET(x) offsetof(FlatContext, x)
 
-static const AVOption flat_options[]= {
-    {"sep_char", "set separator",    OFFSET(sep_str),    AV_OPT_TYPE_STRING, {.str="."},  0, 0 },
-    {"s",        "set separator",    OFFSET(sep_str),    AV_OPT_TYPE_STRING, {.str="."},  0, 0 },
-    {"hierarchical", "specify if the section specification should be hierarchical", OFFSET(hierarchical), AV_OPT_TYPE_BOOL, {.i64=1}, 0, 1 },
-    {"h",            "specify if the section specification should be hierarchical", OFFSET(hierarchical), AV_OPT_TYPE_BOOL, {.i64=1}, 0, 1 },
-    {NULL},
+static const AVOption flat_options[] = {
+    { "sep_char",     "set separator",                                               OFFSET(sep_str),      AV_OPT_TYPE_STRING, { .str = "." }, 0, 0 },
+    { "s",            "set separator",                                               OFFSET(sep_str),      AV_OPT_TYPE_STRING, { .str = "." }, 0, 0 },
+    { "hierarchical", "specify if the section specification should be hierarchical", OFFSET(hierarchical), AV_OPT_TYPE_BOOL,   { .i64 = 1   }, 0, 1 },
+    { "h",            "specify if the section specification should be hierarchical", OFFSET(hierarchical), AV_OPT_TYPE_BOOL,   { .i64 = 1   }, 0, 1 },
+    { NULL },
 };
 
 DEFINE_FORMATTER_CLASS(flat);
@@ -126,16 +126,18 @@ static void flat_print_section_header(AVTextFormatContext *wctx, const void *dat
     av_bprint_clear(buf);
     if (!parent_section)
         return;
-    av_bprintf(buf, "%s", wctx->section_pbuf[wctx->level-1].str);
+
+    av_bprintf(buf, "%s", wctx->section_pbuf[wctx->level - 1].str);
 
     if (flat->hierarchical ||
-        !(section->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY|AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER))) {
+        !(section->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY | AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER))) {
         av_bprintf(buf, "%s%s", wctx->section[wctx->level]->name, flat->sep_str);
 
         if (parent_section->flags & AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY) {
-            int n = parent_section->flags & AV_TEXTFORMAT_SECTION_FLAG_NUMBERING_BY_TYPE ?
-                wctx->nb_item_type[wctx->level-1][section->id] :
-                wctx->nb_item[wctx->level-1];
+            int n = parent_section->flags & AV_TEXTFORMAT_SECTION_FLAG_NUMBERING_BY_TYPE
+                ? wctx->nb_item_type[wctx->level - 1][section->id]
+                : wctx->nb_item[wctx->level - 1];
+
             av_bprintf(buf, "%d%s", n, flat->sep_str);
         }
     }
@@ -166,6 +168,6 @@ const AVTextFormatter avtextformatter_flat = {
     .print_section_header  = flat_print_section_header,
     .print_integer         = flat_print_int,
     .print_string          = flat_print_str,
-    .flags = AV_TEXTFORMAT_FLAG_SUPPORTS_OPTIONAL_FIELDS|AV_TEXTFORMAT_FLAG_SUPPORTS_MIXED_ARRAY_CONTENT,
+    .flags = AV_TEXTFORMAT_FLAG_SUPPORTS_OPTIONAL_FIELDS | AV_TEXTFORMAT_FLAG_SUPPORTS_MIXED_ARRAY_CONTENT,
     .priv_class            = &flat_class,
 };

--- a/fftools/textformat/tf_ini.c
+++ b/fftools/textformat/tf_ini.c
@@ -28,21 +28,7 @@
 
 #include "libavutil/bprint.h"
 #include "libavutil/opt.h"
-
-#define writer_w8(wctx_, b_) (wctx_)->writer->writer->writer_w8((wctx_)->writer, b_)
-#define writer_put_str(wctx_, str_) (wctx_)->writer->writer->writer_put_str((wctx_)->writer, str_)
-#define writer_printf(wctx_, fmt_, ...) (wctx_)->writer->writer->writer_printf((wctx_)->writer, fmt_, __VA_ARGS__)
-
-#define DEFINE_FORMATTER_CLASS(name)                   \
-static const char *name##_get_name(void *ctx)       \
-{                                                   \
-    return #name ;                                  \
-}                                                   \
-static const AVClass name##_class = {               \
-    .class_name = #name,                            \
-    .item_name  = name##_get_name,                  \
-    .option     = name##_options                    \
-}
+#include "tf_internal.h"
 
 /* Default output */
 
@@ -104,9 +90,11 @@ static void ini_print_section_header(AVTextFormatContext *wctx, const void *data
 {
     INIContext *ini = wctx->priv;
     AVBPrint *buf = &wctx->section_pbuf[wctx->level];
-    const struct AVTextFormatSection *section = wctx->section[wctx->level];
-    const struct AVTextFormatSection *parent_section = wctx->level ?
-        wctx->section[wctx->level-1] : NULL;
+    const AVTextFormatSection *section = tf_get_section(wctx, wctx->level);
+    const AVTextFormatSection *parent_section = tf_get_parent_section(wctx, wctx->level);
+
+    if (!section)
+        return;
 
     av_bprint_clear(buf);
     if (!parent_section) {

--- a/fftools/textformat/tf_ini.c
+++ b/fftools/textformat/tf_ini.c
@@ -64,9 +64,9 @@ typedef struct INIContext {
 #define OFFSET(x) offsetof(INIContext, x)
 
 static const AVOption ini_options[] = {
-    {"hierarchical", "specify if the section specification should be hierarchical", OFFSET(hierarchical), AV_OPT_TYPE_BOOL, {.i64=1}, 0, 1 },
-    {"h",            "specify if the section specification should be hierarchical", OFFSET(hierarchical), AV_OPT_TYPE_BOOL, {.i64=1}, 0, 1 },
-    {NULL},
+    { "hierarchical", "specify if the section specification should be hierarchical", OFFSET(hierarchical), AV_OPT_TYPE_BOOL, { .i64 = 1 }, 0, 1 },
+    { "h",            "specify if the section specification should be hierarchical", OFFSET(hierarchical), AV_OPT_TYPE_BOOL, { .i64 = 1 }, 0, 1 },
+    { NULL },
 };
 
 DEFINE_FORMATTER_CLASS(ini);
@@ -74,9 +74,9 @@ DEFINE_FORMATTER_CLASS(ini);
 static char *ini_escape_str(AVBPrint *dst, const char *src)
 {
     int i = 0;
-    char c = 0;
+    char c;
 
-    while (c = src[i++]) {
+    while ((c = src[i++])) {
         switch (c) {
         case '\b': av_bprintf(dst, "%s", "\\b"); break;
         case '\f': av_bprintf(dst, "%s", "\\f"); break;
@@ -84,9 +84,11 @@ static char *ini_escape_str(AVBPrint *dst, const char *src)
         case '\r': av_bprintf(dst, "%s", "\\r"); break;
         case '\t': av_bprintf(dst, "%s", "\\t"); break;
         case '\\':
-        case '#' :
-        case '=' :
-        case ':' : av_bprint_chars(dst, '\\', 1);
+        case '#':
+        case '=':
+        case ':':
+            av_bprint_chars(dst, '\\', 1);
+            /* fallthrough */
         default:
             if ((unsigned char)c < 32)
                 av_bprintf(dst, "\\x00%02x", c & 0xff);
@@ -112,23 +114,23 @@ static void ini_print_section_header(AVTextFormatContext *wctx, const void *data
         return;
     }
 
-    if (wctx->nb_item[wctx->level-1])
+    if (wctx->nb_item[wctx->level - 1])
         writer_w8(wctx, '\n');
 
-    av_bprintf(buf, "%s", wctx->section_pbuf[wctx->level-1].str);
+    av_bprintf(buf, "%s", wctx->section_pbuf[wctx->level - 1].str);
     if (ini->hierarchical ||
-        !(section->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY|AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER))) {
+        !(section->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY | AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER))) {
         av_bprintf(buf, "%s%s", buf->str[0] ? "." : "", wctx->section[wctx->level]->name);
 
         if (parent_section->flags & AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY) {
-            int n = parent_section->flags & AV_TEXTFORMAT_SECTION_FLAG_NUMBERING_BY_TYPE ?
-                wctx->nb_item_type[wctx->level-1][section->id] :
-                wctx->nb_item[wctx->level-1];
-            av_bprintf(buf, ".%d", n);
+            unsigned n = parent_section->flags & AV_TEXTFORMAT_SECTION_FLAG_NUMBERING_BY_TYPE
+                ? wctx->nb_item_type[wctx->level - 1][section->id]
+                : wctx->nb_item[wctx->level - 1];
+            av_bprintf(buf, ".%u", n);
         }
     }
 
-    if (!(section->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY|AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER)))
+    if (!(section->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY | AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER)))
         writer_printf(wctx, "[%s]\n", buf->str);
 }
 
@@ -154,6 +156,6 @@ const AVTextFormatter avtextformatter_ini = {
     .print_section_header  = ini_print_section_header,
     .print_integer         = ini_print_int,
     .print_string          = ini_print_str,
-    .flags = AV_TEXTFORMAT_FLAG_SUPPORTS_OPTIONAL_FIELDS|AV_TEXTFORMAT_FLAG_SUPPORTS_MIXED_ARRAY_CONTENT,
+    .flags = AV_TEXTFORMAT_FLAG_SUPPORTS_OPTIONAL_FIELDS | AV_TEXTFORMAT_FLAG_SUPPORTS_MIXED_ARRAY_CONTENT,
     .priv_class            = &ini_class,
 };

--- a/fftools/textformat/tf_ini.c
+++ b/fftools/textformat/tf_ini.c
@@ -91,7 +91,7 @@ static char *ini_escape_str(AVBPrint *dst, const char *src)
             /* fallthrough */
         default:
             if ((unsigned char)c < 32)
-                av_bprintf(dst, "\\x00%02x", c & 0xff);
+                av_bprintf(dst, "\\x00%02x", (unsigned char)c);
             else
                 av_bprint_chars(dst, c, 1);
             break;

--- a/fftools/textformat/tf_internal.h
+++ b/fftools/textformat/tf_internal.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) The FFmpeg developers
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file
+ * Internal utilities for text formatters.
+ */
+
+#ifndef FFTOOLS_TEXTFORMAT_TF_INTERNAL_H
+#define FFTOOLS_TEXTFORMAT_TF_INTERNAL_H
+
+#include "avtextformat.h"
+
+#define DEFINE_FORMATTER_CLASS(name)                \
+static const char *name##_get_name(void *ctx)       \
+{                                                   \
+    return #name ;                                  \
+}                                                   \
+static const AVClass name##_class = {               \
+    .class_name = #name,                            \
+    .item_name  = name##_get_name,                  \
+    .option     = name##_options                    \
+}
+
+
+/**
+ * Safely validate and access a section at a given level
+ */
+static inline const AVTextFormatSection *tf_get_section(AVTextFormatContext *tfc, int level)
+{
+    if (!tfc || level < 0 || level >= SECTION_MAX_NB_LEVELS || !tfc->section[level]) {
+        if (tfc)
+            av_log(tfc, AV_LOG_ERROR, "Invalid section access at level %d\n", level);
+        return NULL;
+    }
+    return tfc->section[level];
+}
+
+/**
+ * Safely access the parent section
+ */
+static inline const AVTextFormatSection *tf_get_parent_section(AVTextFormatContext *tfc, int level)
+{
+    if (level <= 0)
+        return NULL;
+
+    return tf_get_section(tfc, level - 1);
+}
+
+static inline void writer_w8(AVTextFormatContext *wctx, int b)
+{
+    wctx->writer->writer->writer_w8(wctx->writer, b);
+}
+
+static inline void writer_put_str(AVTextFormatContext *wctx, const char *str)
+{
+    wctx->writer->writer->writer_put_str(wctx->writer, str);
+}
+
+static inline void writer_printf(AVTextFormatContext *wctx, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    wctx->writer->writer->writer_vprintf(wctx->writer, fmt, args);
+    va_end(args);
+}
+
+#endif /* FFTOOLS_TEXTFORMAT_TF_INTERNAL_H */

--- a/fftools/textformat/tf_internal.h
+++ b/fftools/textformat/tf_internal.h
@@ -29,13 +29,9 @@
 #include "avtextformat.h"
 
 #define DEFINE_FORMATTER_CLASS(name)                \
-static const char *name##_get_name(void *ctx)       \
-{                                                   \
-    return #name ;                                  \
-}                                                   \
 static const AVClass name##_class = {               \
     .class_name = #name,                            \
-    .item_name  = name##_get_name,                  \
+    .item_name  = av_default_item_name,             \
     .option     = name##_options                    \
 }
 

--- a/fftools/textformat/tf_json.c
+++ b/fftools/textformat/tf_json.c
@@ -56,9 +56,9 @@ typedef struct JSONContext {
 #undef OFFSET
 #define OFFSET(x) offsetof(JSONContext, x)
 
-static const AVOption json_options[]= {
-    { "compact", "enable compact output", OFFSET(compact), AV_OPT_TYPE_BOOL, {.i64=0}, 0, 1 },
-    { "c",       "enable compact output", OFFSET(compact), AV_OPT_TYPE_BOOL, {.i64=0}, 0, 1 },
+static const AVOption json_options[] = {
+    { "compact", "enable compact output", OFFSET(compact), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1 },
+    { "c",       "enable compact output", OFFSET(compact), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1 },
     { NULL }
 };
 
@@ -76,8 +76,8 @@ static av_cold int json_init(AVTextFormatContext *wctx)
 
 static const char *json_escape_str(AVBPrint *dst, const char *src, void *log_ctx)
 {
-    static const char json_escape[] = {'"', '\\', '\b', '\f', '\n', '\r', '\t', 0};
-    static const char json_subst[]  = {'"', '\\',  'b',  'f',  'n',  'r',  't', 0};
+    static const char json_escape[] = { '"', '\\', '\b', '\f', '\n', '\r', '\t', 0 };
+    static const char json_subst[]  = { '"', '\\',  'b',  'f',  'n',  'r',  't', 0 };
     const char *p;
 
     for (p = src; *p; p++) {

--- a/fftools/textformat/tf_mermaid.c
+++ b/fftools/textformat/tf_mermaid.c
@@ -1,0 +1,658 @@
+/*
+ * Copyright (c) The FFmpeg developers
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <limits.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "avtextformat.h"
+#include "tf_internal.h"
+#include "tf_mermaid.h"
+#include <libavutil/mem.h>
+#include <libavutil/avassert.h>
+#include <libavutil/bprint.h>
+#include <libavutil/opt.h>
+
+
+static const char *init_directive = ""
+    "%%{init: {"
+        "\"theme\": \"base\","
+        "\"curve\": \"monotoneX\","
+        "\"rankSpacing\": 10,"
+        "\"nodeSpacing\": 10,"
+        "\"themeCSS\": \"__###__\","
+        "\"fontFamily\": \"Roboto,Segoe UI,sans-serif\","
+        "\"themeVariables\": { "
+            "\"clusterBkg\": \"white\", "
+            "\"primaryBorderColor\": \"gray\", "
+            "\"lineColor\": \"gray\", "
+            "\"secondaryTextColor\": \"gray\", "
+            "\"tertiaryBorderColor\": \"gray\", "
+            "\"primaryTextColor\": \"#666\", "
+            "\"secondaryTextColor\": \"red\" "
+        "},"
+        "\"flowchart\": { "
+            "\"subGraphTitleMargin\": { \"top\": -15, \"bottom\": 20 }, "
+            "\"diagramPadding\": 20, "
+            "\"curve\": \"monotoneX\" "
+        "}"
+    " }}%%\n\n";
+
+static const char* init_directive_er = ""
+    "%%{init: {"
+        "\"theme\": \"base\","
+        "\"layout\": \"elk\","
+        "\"curve\": \"monotoneX\","
+        "\"rankSpacing\": 65,"
+        "\"nodeSpacing\": 60,"
+        "\"themeCSS\": \"__###__\","
+        "\"fontFamily\": \"Roboto,Segoe UI,sans-serif\","
+        "\"themeVariables\": { "
+            "\"clusterBkg\": \"white\", "
+            "\"primaryBorderColor\": \"gray\", "
+            "\"lineColor\": \"gray\", "
+            "\"secondaryTextColor\": \"gray\", "
+            "\"tertiaryBorderColor\": \"gray\", "
+            "\"primaryTextColor\": \"#666\", "
+            "\"secondaryTextColor\": \"red\" "
+        "},"
+        "\"er\": { "
+            "\"diagramPadding\": 12, "
+            "\"entityPadding\": 4, "
+            "\"minEntityWidth\": 150, "
+            "\"minEntityHeight\": 20, "
+            "\"curve\": \"monotoneX\" "
+        "}"
+    " }}%%\n\n";
+
+static const char *theme_css_er = ""
+
+    // Variables
+            ".root { "
+                "--ff-colvideo: #6eaa7b; "
+                "--ff-colaudio: #477fb3; "
+                "--ff-colsubtitle: #ad76ab; "
+                "--ff-coltext: #666; "
+            "} "
+            " g.nodes g.node.default rect.basic.label-container, "
+            " g.nodes g.node.default path { "
+            "     rx: 1; "
+            "     ry: 1; "
+            "     stroke-width: 1px !important; "
+            "     stroke: #e9e9e9 !important; "
+            "     fill: url(#ff-filtergradient) !important; "
+            "     filter: drop-shadow(0px 0px 5.5px rgba(0, 0, 0, 0.05)); "
+            "     fill: white !important; "
+            " } "
+            "  "
+            " .relationshipLine { "
+            "     stroke: gray; "
+            "     stroke-width: 1; "
+            "     fill: none; "
+            "     filter: drop-shadow(0px 0px 3px rgba(0, 0, 0, 0.2)); "
+            " } "
+            "  "
+            " g.node.default g.label.name  foreignObject > div > span > p, "
+            " g.nodes g.node.default g.label:not(.attribute-name, .attribute-keys, .attribute-type, .attribute-comment) foreignObject > div > span > p { "
+            "     font-size: 0.95rem; "
+            "     font-weight: 500; "
+            "     text-transform: uppercase; "
+            "     min-width: 5.5rem; "
+            "     margin-bottom: 0.5rem; "
+            "      "
+            " } "
+            "  "
+            " .edgePaths path { "
+            "     marker-end: none; "
+            "     marker-start: none; "
+            "  "
+            "} ";
+
+
+/* Mermaid Graph output */
+
+typedef struct MermaidContext {
+    const AVClass *class;
+    AVDiagramConfig *diagram_config;
+    int subgraph_count;
+    int within_tag;
+    int indent_level;
+    int create_html;
+
+    // Options
+    int enable_link_colors; // Requires Mermaid 11.5
+
+    struct section_data {
+        const char *section_id;
+        const char *section_type;
+        const char *src_id;
+        const char *dest_id;
+        AVTextFormatLinkType link_type;
+        int current_is_textblock;
+        int current_is_stadium;
+        int subgraph_start_incomplete;
+    }  section_data[SECTION_MAX_NB_LEVELS];
+
+    unsigned nb_link_captions[SECTION_MAX_NB_LEVELS]; ///< generic print buffer dedicated to each section,
+    AVBPrint section_pbuf[SECTION_MAX_NB_LEVELS]; ///< generic print buffer dedicated to each section,
+    AVBPrint link_buf; ///< print buffer for writing diagram links
+    AVDictionary *link_dict;
+} MermaidContext;
+
+#undef OFFSET
+#define OFFSET(x) offsetof(MermaidContext, x)
+
+static const AVOption mermaid_options[] = {
+    { "link_coloring",    "enable colored links (requires Mermaid >= 11.5)",  OFFSET(enable_link_colors), AV_OPT_TYPE_BOOL,   { .i64 = 1 },  0, 1 },
+    ////{"diagram_css",      "CSS for the diagram",                              OFFSET(diagram_css),        AV_OPT_TYPE_STRING, {.i64=0},  0, 1 },
+    ////{"html_template",    "Template HTML",                                    OFFSET(html_template),      AV_OPT_TYPE_STRING, {.i64=0},  0, 1 },
+    { NULL },
+};
+
+DEFINE_FORMATTER_CLASS(mermaid);
+
+void av_diagram_init(AVTextFormatContext *tfc, AVDiagramConfig *diagram_config)
+{
+    MermaidContext *mmc = tfc->priv;
+    mmc->diagram_config = diagram_config;
+}
+
+static av_cold int has_link_pair(const AVTextFormatContext *tfc, const char *src, const char *dest)
+{
+    MermaidContext *mmc = tfc->priv;
+    AVBPrint buf;
+
+    av_bprint_init(&buf, 0, AV_BPRINT_SIZE_UNLIMITED);
+    av_bprintf(&buf, "%s--%s", src, dest);
+
+    if (mmc->link_dict && av_dict_get(mmc->link_dict, buf.str, NULL, 0))
+        return 1;
+
+    av_dict_set(&mmc->link_dict, buf.str, buf.str, 0);
+
+    return 0;
+}
+
+static av_cold int mermaid_init(AVTextFormatContext *tfc)
+{
+    MermaidContext *mmc = tfc->priv;
+
+    av_bprint_init(&mmc->link_buf, 0, AV_BPRINT_SIZE_UNLIMITED);
+
+    ////mmc->enable_link_colors = 1; // Requires Mermaid 11.5
+    return 0;
+}
+
+static av_cold int mermaid_init_html(AVTextFormatContext *tfc)
+{
+    MermaidContext *mmc = tfc->priv;
+
+    int ret = mermaid_init(tfc);
+
+    if (ret < 0)
+        return ret;
+
+    mmc->create_html = 1;
+
+    return 0;
+}
+
+#define MM_INDENT() writer_printf(tfc, "%*c", mmc->indent_level * 2, ' ')
+
+static void mermaid_print_section_header(AVTextFormatContext *tfc, const void *data)
+{
+    const AVTextFormatSection *section = tf_get_section(tfc, tfc->level);
+    const AVTextFormatSection *parent_section = tf_get_parent_section(tfc, tfc->level);
+
+    if (!section)
+        return;
+    AVBPrint *buf = &tfc->section_pbuf[tfc->level];
+    MermaidContext *mmc = tfc->priv;
+    const AVTextFormatSectionContext *sec_ctx = data;
+
+    if (tfc->level == 0) {
+        char *directive;
+        AVBPrint css_buf;
+        const char *diag_directive = mmc->diagram_config->diagram_type == AV_DIAGRAMTYPE_ENTITYRELATIONSHIP ? init_directive_er : init_directive;
+        char *single_line_css = av_strireplace(mmc->diagram_config->diagram_css, "\n", " ");
+        (void)theme_css_er;
+        ////char *single_line_css = av_strireplace(theme_css_er, "\n", " ");
+        av_bprint_init(&css_buf, 0, AV_BPRINT_SIZE_UNLIMITED);
+        av_bprint_escape(&css_buf, single_line_css, "'\\", AV_ESCAPE_MODE_BACKSLASH, AV_ESCAPE_FLAG_STRICT);
+        av_freep(&single_line_css);
+
+        directive = av_strireplace(diag_directive, "__###__", css_buf.str);
+        if (mmc->create_html) {
+            uint64_t length;
+            char *token_pos = av_stristr(mmc->diagram_config->html_template, "__###__");
+            if (!token_pos) {
+                av_log(tfc, AV_LOG_ERROR, "Unable to locate the required token (__###__) in the html template.");
+                return;
+            }
+
+            length = token_pos - mmc->diagram_config->html_template;
+            for (uint64_t i = 0; i < length; i++)
+                writer_w8(tfc, mmc->diagram_config->html_template[i]);
+        }
+
+        writer_put_str(tfc, directive);
+        switch (mmc->diagram_config->diagram_type) {
+        case AV_DIAGRAMTYPE_GRAPH:
+            writer_put_str(tfc, "flowchart LR\n");
+        ////writer_put_str(tfc, "  gradient_def@{ shape: text, label: \"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"1\" height=\"1\"><defs><linearGradient id=\"ff-filtergradient\" x1=\"0%\" y1=\"0%\" x2=\"0%\" y2=\"100%\"><stop offset=\"0%\" style=\"stop-color:hsla(0, 0%, 30%, 0.02);\"/><stop offset=\"50%\" style=\"stop-color:hsla(0, 0%, 30%, 0);\"/><stop offset=\"100%\" style=\"stop-color:hsla(0, 0%, 30%, 0.05);\"/></linearGradient></defs></svg>\" }\n");
+            writer_put_str(tfc, "  gradient_def@{ shape: text, label: \"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"1\" height=\"1\"><defs><linearGradient id=\"ff-filtergradient\" x1=\"0%\" y1=\"0%\" x2=\"0%\" y2=\"100%\"><stop offset=\"0%\" style=\"stop-color:hsl(0, 0%, 98.6%);     \"/><stop offset=\"50%\" style=\"stop-color:hsl(0, 0%, 100%);   \"/><stop offset=\"100%\" style=\"stop-color:hsl(0, 0%, 96.5%);     \"/></linearGradient><radialGradient id=\"ff-radgradient\" cx=\"50%\" cy=\"50%\" r=\"100%\" fx=\"45%\" fy=\"40%\"><stop offset=\"25%\" stop-color=\"hsl(0, 0%, 100%)\" /><stop offset=\"100%\" stop-color=\"hsl(0, 0%, 96%)\" /></radialGradient></defs></svg>\" }\n");
+            break;
+        case AV_DIAGRAMTYPE_ENTITYRELATIONSHIP:
+            writer_put_str(tfc, "erDiagram\n");
+            break;
+        }
+
+        return;
+    }
+
+    if (parent_section && parent_section->flags & AV_TEXTFORMAT_SECTION_FLAG_IS_SUBGRAPH) {
+
+        struct section_data parent_sec_data = mmc->section_data[tfc->level - 1];
+        AVBPrint *parent_buf = &tfc->section_pbuf[tfc->level - 1];
+
+        if (parent_sec_data.subgraph_start_incomplete) {
+
+            if (parent_buf->len > 0)
+                writer_printf(tfc, "%s", parent_buf->str);
+
+            writer_put_str(tfc, "</div>\"]\n");
+
+            mmc->section_data[tfc->level - 1].subgraph_start_incomplete = 0;
+        }
+    }
+
+    av_freep(&mmc->section_data[tfc->level].section_id);
+    av_freep(&mmc->section_data[tfc->level].section_type);
+    av_freep(&mmc->section_data[tfc->level].src_id);
+    av_freep(&mmc->section_data[tfc->level].dest_id);
+    mmc->section_data[tfc->level].current_is_textblock = 0;
+    mmc->section_data[tfc->level].current_is_stadium = 0;
+    mmc->section_data[tfc->level].subgraph_start_incomplete = 0;
+    mmc->section_data[tfc->level].link_type = AV_TEXTFORMAT_LINKTYPE_SRCDEST;
+
+    // NOTE: av_strdup() allocations aren't checked
+    if (section->flags & AV_TEXTFORMAT_SECTION_FLAG_IS_SUBGRAPH) {
+
+        av_bprint_clear(buf);
+        writer_put_str(tfc, "\n");
+
+        mmc->indent_level++;
+
+        if (sec_ctx->context_id) {
+            MM_INDENT();
+            writer_printf(tfc, "subgraph %s[\"<div class=\"ff-%s\">", sec_ctx->context_id, section->name);
+        } else {
+            av_log(tfc, AV_LOG_ERROR, "Unable to write subgraph start. Missing id field. Section: %s", section->name);
+        }
+
+        mmc->section_data[tfc->level].subgraph_start_incomplete = 1;
+        mmc->section_data[tfc->level].section_id = av_strdup(sec_ctx->context_id);
+    }
+
+    if (section->flags & AV_TEXTFORMAT_SECTION_FLAG_IS_SHAPE) {
+
+        av_bprint_clear(buf);
+        writer_put_str(tfc, "\n");
+
+        mmc->indent_level++;
+
+        if (sec_ctx->context_id) {
+
+            mmc->section_data[tfc->level].section_id = av_strdup(sec_ctx->context_id);
+
+            switch (mmc->diagram_config->diagram_type) {
+            case AV_DIAGRAMTYPE_GRAPH:
+                if (sec_ctx->context_flags & 1) {
+
+                    MM_INDENT();
+                    writer_printf(tfc, "%s@{ shape: text, label: \"", sec_ctx->context_id);
+                    mmc->section_data[tfc->level].current_is_textblock = 1;
+                } else if (sec_ctx->context_flags & 2) {
+
+                    MM_INDENT();
+                    writer_printf(tfc, "%s([\"", sec_ctx->context_id);
+                    mmc->section_data[tfc->level].current_is_stadium = 1;
+                } else {
+                    MM_INDENT();
+                    writer_printf(tfc, "%s(\"", sec_ctx->context_id);
+                }
+
+                break;
+            case AV_DIAGRAMTYPE_ENTITYRELATIONSHIP:
+                MM_INDENT();
+                writer_printf(tfc, "%s {\n", sec_ctx->context_id);
+                break;
+            }
+
+        } else {
+            av_log(tfc, AV_LOG_ERROR, "Unable to write shape start. Missing id field. Section: %s", section->name);
+        }
+
+        mmc->section_data[tfc->level].section_id = av_strdup(sec_ctx->context_id);
+    }
+
+
+    if (section->flags & AV_TEXTFORMAT_SECTION_PRINT_TAGS) {
+
+        if (sec_ctx && sec_ctx->context_type)
+            writer_printf(tfc, "<div class=\"ff-%s %s\">", section->name, sec_ctx->context_type);
+        else
+            writer_printf(tfc, "<div class=\"ff-%s\">", section->name);
+    }
+
+
+    if (section->flags & AV_TEXTFORMAT_SECTION_FLAG_HAS_LINKS) {
+
+        av_bprint_clear(buf);
+        mmc->nb_link_captions[tfc->level] = 0;
+
+        if (sec_ctx && sec_ctx->context_type)
+            mmc->section_data[tfc->level].section_type = av_strdup(sec_ctx->context_type);
+
+        ////if (section->flags & AV_TEXTFORMAT_SECTION_FLAG_HAS_TYPE) {
+        ////    AVBPrint buf;
+        ////    av_bprint_init(&buf, 1, AV_BPRINT_SIZE_UNLIMITED);
+        ////    av_bprint_escape(&buf, section->get_type(data), NULL,
+        ////                     AV_ESCAPE_MODE_XML, AV_ESCAPE_FLAG_XML_DOUBLE_QUOTES);
+        ////    writer_printf(tfc, " type=\"%s\"", buf.str);
+    }
+}
+
+static void mermaid_print_section_footer(AVTextFormatContext *tfc)
+{
+    MermaidContext *mmc = tfc->priv;
+    const AVTextFormatSection *section = tf_get_section(tfc, tfc->level);
+
+    if (!section)
+        return;
+    AVBPrint *buf = &tfc->section_pbuf[tfc->level];
+    struct section_data sec_data = mmc->section_data[tfc->level];
+
+    if (section->flags & AV_TEXTFORMAT_SECTION_PRINT_TAGS)
+        writer_put_str(tfc, "</div>");
+
+    if (section->flags & AV_TEXTFORMAT_SECTION_FLAG_IS_SHAPE) {
+
+        switch (mmc->diagram_config->diagram_type) {
+        case AV_DIAGRAMTYPE_GRAPH:
+
+            if (sec_data.current_is_textblock) {
+                writer_printf(tfc, "\"}\n", section->name);
+
+                if (sec_data.section_id) {
+                    MM_INDENT();
+                    writer_put_str(tfc, "class ");
+                    writer_put_str(tfc, sec_data.section_id);
+                    writer_put_str(tfc, " ff-");
+                    writer_put_str(tfc, section->name);
+                    writer_put_str(tfc, "\n");
+                }
+            } else if (sec_data.current_is_stadium) {
+                writer_printf(tfc, "\"]):::ff-%s\n", section->name);
+            } else {
+                writer_printf(tfc, "\"):::ff-%s\n", section->name);
+            }
+
+            break;
+        case AV_DIAGRAMTYPE_ENTITYRELATIONSHIP:
+            MM_INDENT();
+            writer_put_str(tfc, "}\n\n");
+            break;
+        }
+
+        mmc->indent_level--;
+
+    } else if ((section->flags & AV_TEXTFORMAT_SECTION_FLAG_IS_SUBGRAPH)) {
+
+        MM_INDENT();
+        writer_put_str(tfc, "end\n");
+
+        if (sec_data.section_id) {
+            MM_INDENT();
+            writer_put_str(tfc, "class ");
+            writer_put_str(tfc, sec_data.section_id);
+            writer_put_str(tfc, " ff-");
+            writer_put_str(tfc, section->name);
+            writer_put_str(tfc, "\n");
+        }
+
+        mmc->indent_level--;
+    }
+
+    if ((section->flags & AV_TEXTFORMAT_SECTION_FLAG_HAS_LINKS))
+        if (sec_data.src_id && sec_data.dest_id
+            && !has_link_pair(tfc, sec_data.src_id, sec_data.dest_id))
+            switch (mmc->diagram_config->diagram_type) {
+            case AV_DIAGRAMTYPE_GRAPH:
+
+                if (sec_data.section_type && mmc->enable_link_colors)
+                    av_bprintf(&mmc->link_buf, "\n  %s %s-%s-%s@==", sec_data.src_id, sec_data.section_type, sec_data.src_id, sec_data.dest_id);
+                else
+                    av_bprintf(&mmc->link_buf, "\n  %s ==", sec_data.src_id);
+
+                if (buf->len > 0) {
+                    av_bprintf(&mmc->link_buf, " \"%s", buf->str);
+
+                    for (unsigned i = 0; i < mmc->nb_link_captions[tfc->level]; i++)
+                        av_bprintf(&mmc->link_buf, "<br>&nbsp;");
+
+                    av_bprintf(&mmc->link_buf, "\" ==");
+                }
+
+                av_bprintf(&mmc->link_buf, "> %s", sec_data.dest_id);
+
+                break;
+            case AV_DIAGRAMTYPE_ENTITYRELATIONSHIP:
+
+
+                av_bprintf(&mmc->link_buf, "\n  %s", sec_data.src_id);
+
+                switch (sec_data.link_type) {
+                case AV_TEXTFORMAT_LINKTYPE_ONETOMANY:
+                    av_bprintf(&mmc->link_buf, "%s", " ||--o{ ");
+                    break;
+                case AV_TEXTFORMAT_LINKTYPE_MANYTOONE:
+                    av_bprintf(&mmc->link_buf, "%s", " }o--|| ");
+                    break;
+                case AV_TEXTFORMAT_LINKTYPE_ONETOONE:
+                    av_bprintf(&mmc->link_buf, "%s", " ||--|| ");
+                    break;
+                case AV_TEXTFORMAT_LINKTYPE_MANYTOMANY:
+                    av_bprintf(&mmc->link_buf, "%s", " }o--o{ ");
+                    break;
+                default:
+                    av_bprintf(&mmc->link_buf, "%s", " ||--|| ");
+                    break;
+                }
+
+                av_bprintf(&mmc->link_buf, "%s : \"\"", sec_data.dest_id);
+
+                break;
+            }
+
+    if (tfc->level == 0) {
+
+        writer_put_str(tfc, "\n");
+        if (mmc->create_html) {
+            char *token_pos = av_stristr(mmc->diagram_config->html_template, "__###__");
+            if (!token_pos) {
+                av_log(tfc, AV_LOG_ERROR, "Unable to locate the required token (__###__) in the html template.");
+                return;
+            }
+            token_pos += strlen("__###__");
+            writer_put_str(tfc, token_pos);
+        }
+    }
+
+    if (tfc->level == 1) {
+
+        if (mmc->link_buf.len > 0) {
+            writer_put_str(tfc, mmc->link_buf.str);
+            av_bprint_clear(&mmc->link_buf);
+        }
+
+        writer_put_str(tfc, "\n");
+    }
+}
+
+static void mermaid_print_value(AVTextFormatContext *tfc, const char *key,
+                                const char *str, int64_t num, const int is_int)
+{
+    MermaidContext *mmc = tfc->priv;
+    const AVTextFormatSection *section = tf_get_section(tfc, tfc->level);
+
+    if (!section)
+        return;
+
+    AVBPrint *buf = &tfc->section_pbuf[tfc->level];
+    struct section_data sec_data = mmc->section_data[tfc->level];
+    int exit = 0;
+
+    if (section->id_key && !strcmp(section->id_key, key)) {
+        mmc->section_data[tfc->level].section_id = av_strdup(str);
+        exit = 1;
+    }
+
+    if (section->dest_id_key && !strcmp(section->dest_id_key, key)) {
+        mmc->section_data[tfc->level].dest_id = av_strdup(str);
+        exit = 1;
+    }
+
+    if (section->src_id_key && !strcmp(section->src_id_key, key)) {
+        mmc->section_data[tfc->level].src_id = av_strdup(str);
+        exit = 1;
+    }
+
+    if (section->linktype_key && !strcmp(section->linktype_key, key)) {
+        mmc->section_data[tfc->level].link_type = (AVTextFormatLinkType)num;;
+        exit = 1;
+    }
+
+    //if (exit)
+    //    return;
+
+    if ((section->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_SHAPE | AV_TEXTFORMAT_SECTION_PRINT_TAGS))
+        || (section->flags & AV_TEXTFORMAT_SECTION_FLAG_IS_SUBGRAPH && sec_data.subgraph_start_incomplete)) {
+
+        if (exit)
+            return;
+
+        switch (mmc->diagram_config->diagram_type) {
+        case AV_DIAGRAMTYPE_GRAPH:
+
+            if (is_int) {
+                writer_printf(tfc, "<span class=\"%s\">%s: %"PRId64"</span>", key, key, num);
+            } else {
+                ////AVBPrint b;
+                ////av_bprint_init(&b, 0, AV_BPRINT_SIZE_UNLIMITED);
+                const char *tmp = av_strireplace(str, "\"", "'");
+                ////av_bprint_escape(&b, str, NULL, AV_ESCAPE_MODE_AUTO, AV_ESCAPE_FLAG_STRICT);
+                writer_printf(tfc, "<span class=\"%s\">%s</span>", key, tmp);
+                av_freep(&tmp);
+            }
+
+            break;
+        case AV_DIAGRAMTYPE_ENTITYRELATIONSHIP:
+
+            if (!is_int && str)
+            {
+                const char *col_type;
+
+                if (key[0] == '_')
+                    return;
+
+                if (sec_data.section_id && !strcmp(str, sec_data.section_id))
+                    col_type = "PK";
+                else if (sec_data.dest_id && !strcmp(str, sec_data.dest_id))
+                    col_type = "FK";
+                else if (sec_data.src_id && !strcmp(str, sec_data.src_id))
+                    col_type = "FK";
+                else
+                    col_type = "";
+
+                MM_INDENT();
+
+                if (is_int)
+                    writer_printf(tfc, "    %s %"PRId64" %s\n", key, num, col_type);
+                else
+                    writer_printf(tfc, "    %s %s %s\n", key, str, col_type);
+            }
+            break;
+        }
+
+    } else if (section->flags & AV_TEXTFORMAT_SECTION_FLAG_HAS_LINKS) {
+
+        if (exit)
+            return;
+
+        if (buf->len > 0)
+            av_bprintf(buf, "%s", "<br>");
+
+        av_bprintf(buf, "");
+        if (is_int)
+            av_bprintf(buf, "<span>%s: %"PRId64"</span>", key, num);
+        else
+            av_bprintf(buf, "<span>%s</span>", str);
+
+        mmc->nb_link_captions[tfc->level]++;
+    }
+}
+
+static inline void mermaid_print_str(AVTextFormatContext *tfc, const char *key, const char *value)
+{
+    mermaid_print_value(tfc, key, value, 0, 0);
+}
+
+static void mermaid_print_int(AVTextFormatContext *tfc, const char *key, int64_t value)
+{
+    mermaid_print_value(tfc, key, NULL, value, 1);
+}
+
+const AVTextFormatter avtextformatter_mermaid = {
+    .name                 = "mermaid",
+    .priv_size            = sizeof(MermaidContext),
+    .init                 = mermaid_init,
+    .print_section_header = mermaid_print_section_header,
+    .print_section_footer = mermaid_print_section_footer,
+    .print_integer        = mermaid_print_int,
+    .print_string         = mermaid_print_str,
+    .flags = AV_TEXTFORMAT_FLAG_IS_DIAGRAM_FORMATTER,
+    .priv_class           = &mermaid_class,
+};
+
+
+const AVTextFormatter avtextformatter_mermaidhtml = {
+    .name                 = "mermaidhtml",
+    .priv_size            = sizeof(MermaidContext),
+    .init                 = mermaid_init_html,
+    .print_section_header = mermaid_print_section_header,
+    .print_section_footer = mermaid_print_section_footer,
+    .print_integer        = mermaid_print_int,
+    .print_string         = mermaid_print_str,
+    .flags = AV_TEXTFORMAT_FLAG_IS_DIAGRAM_FORMATTER,
+    .priv_class           = &mermaid_class,
+};

--- a/fftools/textformat/tf_mermaid.h
+++ b/fftools/textformat/tf_mermaid.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) The FFmpeg developers
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef FFTOOLS_TEXTFORMAT_TF_MERMAID_H
+#define FFTOOLS_TEXTFORMAT_TF_MERMAID_H
+
+typedef enum {
+    AV_DIAGRAMTYPE_GRAPH,
+    AV_DIAGRAMTYPE_ENTITYRELATIONSHIP,
+} AVDiagramType;
+
+typedef struct AVDiagramConfig {
+    AVDiagramType diagram_type;
+    const char *diagram_css;
+    const char *html_template;
+} AVDiagramConfig;
+
+
+void av_diagram_init(AVTextFormatContext *tfc, AVDiagramConfig *diagram_config);
+
+void av_mermaid_set_html_template(AVTextFormatContext *tfc, const char *html_template);
+
+
+#endif /* FFTOOLS_TEXTFORMAT_TF_MERMAID_H */

--- a/fftools/textformat/tf_xml.c
+++ b/fftools/textformat/tf_xml.c
@@ -58,11 +58,11 @@ typedef struct XMLContext {
 #define OFFSET(x) offsetof(XMLContext, x)
 
 static const AVOption xml_options[] = {
-    {"fully_qualified", "specify if the output should be fully qualified", OFFSET(fully_qualified), AV_OPT_TYPE_BOOL, {.i64=0},  0, 1 },
-    {"q",               "specify if the output should be fully qualified", OFFSET(fully_qualified), AV_OPT_TYPE_BOOL, {.i64=0},  0, 1 },
-    {"xsd_strict",      "ensure that the output is XSD compliant",         OFFSET(xsd_strict),      AV_OPT_TYPE_BOOL, {.i64=0},  0, 1 },
-    {"x",               "ensure that the output is XSD compliant",         OFFSET(xsd_strict),      AV_OPT_TYPE_BOOL, {.i64=0},  0, 1 },
-    {NULL},
+    { "fully_qualified", "specify if the output should be fully qualified", OFFSET(fully_qualified), AV_OPT_TYPE_BOOL, { .i64 = 0 },  0, 1 },
+    { "q",               "specify if the output should be fully qualified", OFFSET(fully_qualified), AV_OPT_TYPE_BOOL, { .i64 = 0 },  0, 1 },
+    { "xsd_strict",      "ensure that the output is XSD compliant",         OFFSET(xsd_strict),      AV_OPT_TYPE_BOOL, { .i64 = 0 },  0, 1 },
+    { "x",               "ensure that the output is XSD compliant",         OFFSET(xsd_strict),      AV_OPT_TYPE_BOOL, { .i64 = 0 },  0, 1 },
+    { NULL },
 };
 
 DEFINE_FORMATTER_CLASS(xml);
@@ -104,8 +104,8 @@ static void xml_print_section_header(AVTextFormatContext *wctx, const void *data
 
         writer_put_str(wctx, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
         writer_printf(wctx, "<%sffprobe%s>\n",
-               xml->fully_qualified ? "ffprobe:" : "",
-               xml->fully_qualified ? qual : "");
+                      xml->fully_qualified ? "ffprobe:" : "",
+                      xml->fully_qualified ? qual : "");
         return;
     }
 
@@ -115,12 +115,13 @@ static void xml_print_section_header(AVTextFormatContext *wctx, const void *data
     }
 
     if (parent_section && (parent_section->flags & AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER) &&
-        wctx->level && wctx->nb_item[wctx->level-1])
+        wctx->level && wctx->nb_item[wctx->level - 1])
         writer_w8(wctx, '\n');
     xml->indent_level++;
 
-    if (section->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY|AV_TEXTFORMAT_SECTION_FLAG_HAS_VARIABLE_FIELDS)) {
-        XML_INDENT(); writer_printf(wctx, "<%s", section->name);
+    if (section->flags & (AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY | AV_TEXTFORMAT_SECTION_FLAG_HAS_VARIABLE_FIELDS)) {
+        XML_INDENT();
+        writer_printf(wctx, "<%s", section->name);
 
         if (section->flags & AV_TEXTFORMAT_SECTION_FLAG_HAS_TYPE) {
             AVBPrint buf;
@@ -131,7 +132,8 @@ static void xml_print_section_header(AVTextFormatContext *wctx, const void *data
         }
         writer_printf(wctx, ">\n", section->name);
     } else {
-        XML_INDENT(); writer_printf(wctx, "<%s ", section->name);
+        XML_INDENT();
+        writer_printf(wctx, "<%s ", section->name);
         xml->within_tag = 1;
     }
 }
@@ -148,7 +150,8 @@ static void xml_print_section_footer(AVTextFormatContext *wctx)
         writer_put_str(wctx, "/>\n");
         xml->indent_level--;
     } else {
-        XML_INDENT(); writer_printf(wctx, "</%s>\n", section->name);
+        XML_INDENT();
+        writer_printf(wctx, "</%s>\n", section->name);
         xml->indent_level--;
     }
 }
@@ -195,7 +198,8 @@ static void xml_print_value(AVTextFormatContext *wctx, const char *key,
     av_bprint_finalize(&buf, NULL);
 }
 
-static inline void xml_print_str(AVTextFormatContext *wctx, const char *key, const char *value) {
+static inline void xml_print_str(AVTextFormatContext *wctx, const char *key, const char *value)
+{
     xml_print_value(wctx, key, value, 0, 0);
 }
 

--- a/fftools/textformat/tf_xml.c
+++ b/fftools/textformat/tf_xml.c
@@ -18,10 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <limits.h>
-#include <stdarg.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 
 #include "avtextformat.h"

--- a/fftools/textformat/tw_avio.c
+++ b/fftools/textformat/tw_avio.c
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #include "avtextwriters.h"
+#include "libavutil/avassert.h"
 
 #include "libavutil/error.h"
 
@@ -53,7 +54,7 @@ static void io_w8(AVTextWriterContext *wctx, int b)
 static void io_put_str(AVTextWriterContext *wctx, const char *str)
 {
     IOWriterContext *ctx = wctx->priv;
-    avio_write(ctx->avio_context, str, strlen(str));
+    avio_write(ctx->avio_context, (const unsigned char *)str, (int)strlen(str));
 }
 
 static void io_printf(AVTextWriterContext *wctx, const char *fmt, ...)
@@ -81,6 +82,10 @@ int avtextwriter_create_file(AVTextWriterContext **pwctx, const char *output_fil
     IOWriterContext *ctx;
     int ret;
 
+    if (!output_filename || !output_filename[0]) {
+        av_log(NULL, AV_LOG_ERROR, "The output_filename cannot be NULL or empty\n");
+        return AVERROR(EINVAL);
+    }
 
     ret = avtextwriter_context_open(pwctx, &avtextwriter_avio);
     if (ret < 0)
@@ -105,6 +110,8 @@ int avtextwriter_create_avio(AVTextWriterContext **pwctx, AVIOContext *avio_ctx,
 {
     IOWriterContext *ctx;
     int ret;
+
+    av_assert0(avio_ctx);
 
     ret = avtextwriter_context_open(pwctx, &avtextwriter_avio);
     if (ret < 0)

--- a/fftools/textformat/tw_avio.c
+++ b/fftools/textformat/tw_avio.c
@@ -57,14 +57,11 @@ static void io_put_str(AVTextWriterContext *wctx, const char *str)
     avio_write(ctx->avio_context, (const unsigned char *)str, (int)strlen(str));
 }
 
-static void io_printf(AVTextWriterContext *wctx, const char *fmt, ...)
+static void io_vprintf(AVTextWriterContext *wctx, const char *fmt, va_list vl)
 {
     IOWriterContext *ctx = wctx->priv;
-    va_list ap;
 
-    va_start(ap, fmt);
-    avio_vprintf(ctx->avio_context, fmt, ap);
-    va_end(ap);
+    avio_vprintf(ctx->avio_context, fmt, vl);
 }
 
 
@@ -73,7 +70,7 @@ const AVTextWriter avtextwriter_avio = {
     .priv_size            = sizeof(IOWriterContext),
     .uninit               = iowriter_uninit,
     .writer_put_str       = io_put_str,
-    .writer_printf        = io_printf,
+    .writer_vprintf       = io_vprintf,
     .writer_w8            = io_w8
 };
 

--- a/fftools/textformat/tw_buffer.c
+++ b/fftools/textformat/tw_buffer.c
@@ -56,14 +56,11 @@ static void buffer_put_str(AVTextWriterContext *wctx, const char *str)
     av_bprintf(ctx->buffer, "%s", str);
 }
 
-static void buffer_printf(AVTextWriterContext *wctx, const char *fmt, ...)
+static void buffer_vprintf(AVTextWriterContext *wctx, const char *fmt, va_list vl)
 {
     BufferWriterContext *ctx = wctx->priv;
 
-    va_list vargs;
-    va_start(vargs, fmt);
-    av_vbprintf(ctx->buffer, fmt, vargs);
-    va_end(vargs);
+    av_vbprintf(ctx->buffer, fmt, vl);
 }
 
 
@@ -72,7 +69,7 @@ const AVTextWriter avtextwriter_buffer = {
     .priv_size            = sizeof(BufferWriterContext),
     .priv_class           = &bufferwriter_class,
     .writer_put_str       = buffer_put_str,
-    .writer_printf        = buffer_printf,
+    .writer_vprintf       = buffer_vprintf,
     .writer_w8            = buffer_w8
 };
 

--- a/fftools/textformat/tw_stdout.c
+++ b/fftools/textformat/tw_stdout.c
@@ -53,13 +53,9 @@ static inline void stdout_put_str(AVTextWriterContext *wctx, const char *str)
     printf("%s", str);
 }
 
-static inline void stdout_printf(AVTextWriterContext *wctx, const char *fmt, ...)
+static inline void stdout_vprintf(AVTextWriterContext *wctx, const char *fmt, va_list vl)
 {
-    va_list ap;
-
-    va_start(ap, fmt);
-    vprintf(fmt, ap);
-    va_end(ap);
+    vprintf(fmt, vl);
 }
 
 
@@ -68,7 +64,7 @@ static const AVTextWriter avtextwriter_stdout = {
     .priv_size            = sizeof(StdOutWriterContext),
     .priv_class           = &stdoutwriter_class,
     .writer_put_str       = stdout_put_str,
-    .writer_printf        = stdout_printf,
+    .writer_vprintf       = stdout_vprintf,
     .writer_w8            = stdout_w8
 };
 

--- a/libavfilter/avfilter.c
+++ b/libavfilter/avfilter.c
@@ -989,6 +989,15 @@ enum AVMediaType avfilter_pad_get_type(const AVFilterPad *pads, int pad_idx)
     return pads[pad_idx].type;
 }
 
+AVBufferRef *avfilter_link_get_hw_frames_ctx(AVFilterLink *link)
+{
+    FilterLink *plink = ff_filter_link(link);
+    if (plink->hw_frames_ctx)
+        return av_buffer_ref(plink->hw_frames_ctx);
+
+    return NULL;
+}
+
 static int default_filter_frame(AVFilterLink *link, AVFrame *frame)
 {
     return ff_filter_frame(link->dst->outputs[0], frame);

--- a/libavfilter/avfilter.h
+++ b/libavfilter/avfilter.h
@@ -97,6 +97,18 @@ const char *avfilter_pad_get_name(const AVFilterPad *pads, int pad_idx);
 enum AVMediaType avfilter_pad_get_type(const AVFilterPad *pads, int pad_idx);
 
 /**
+ * Get the hardware frames context of a filter link.
+ *
+ * @param link an AVFilterLink
+ *
+ * @return a ref-counted copy of the link's hw_frames_ctx field if there is
+ *         a hardware frames context associated with the link or NULL otherwise.
+ *         The returned AVBufferRef needs to be released with av_buffer_unref()
+ *         when it is no longer used.
+ */
+AVBufferRef* avfilter_link_get_hw_frames_ctx(AVFilterLink *link);
+
+/**
  * Lists of formats / etc. supported by an end of a link.
  *
  * This structure is directly part of AVFilterLink, in two copies:


### PR DESCRIPTION
Shortest cover letter for my longest-running FFmpeg patchset:

- Apply
- Build
- Add the "-sg" switch to any FFmpeg command line
- Press 'q' when you don't want to wait

SG = Show Graph


Documentation and examples can be found here:

https://github.com/softworkz/ffmpeg_output_apis/wiki


## Version Updates

### V2

- Rebased on top of Andreas' improvements
- Applied changes from review
  (thanks, Andreas)


### V3

- Fixed all "new warnings"
- Fixed out-of-tree building
  (thanks, Michael)


### V4

- Resolved merge conflict
- Fixed build on MinGW (missing include due to WIN32_LEAN_AND_MEAN being defined)
  (thanks, Michael)


### V5

- Applied changes as per review from Stefano (thanks!)
- Introduced AVTextFormatOptions struct for options in avtext_context_open()


### V6

- Fix "new warning" in 2nd last commit
- Squash patches 04 and 05 (they weren't truely independent)
- Applied changes as per review from Stefano (thanks!)


### V7

- Bitten by OOT builds once again (thanks, Michael)


### V8

- New commit  Remove void (*print_rational) from AVTextFormatter (unused)
- New commit fftools/textformat: Rename `name` param to `key` for API consistency
- print_int Extend existing function instead of adding print_int_flags
- Fix registered_formatters[] array size
- avtextwriters.h: Remove unused includes
- graphprint.c: Make BPrint inits consistent
- tf_json: Check nesting level for value printing 
- And other review suggestions by Stefano (thanks!)


### V9

- Handle cases where no zlib is available (thanks, Michael)   
  and provide configure switch (--disable-resource-compression)


### V10

- Fix shared build by not using private URL API from avformat (thanks, Michael)   


### V11

- Resubmit because Patchwork was broken


### V12

- Apply requested changes from review (thanks, Stefano)


.
