### PR TITLE
fftools/ffprobe: Disable stderr buffering on Windows

### DIFF
--- a/fftools/ffprobe.c
+++ b/fftools/ffprobe.c
@@ -3081,6 +3081,8 @@ int main(int argc, char **argv)
 
     init_dynload();
 
+    setvbuf(stderr, NULL, _IONBF, 0); /* win32 runtime needs this */
+
     av_log_set_flags(AV_LOG_SKIP_REPEATED);
 
     options = real_options;


### PR DESCRIPTION
An identical call exists in ffmpeg.c

With POSIX/glibc, stderr is already unbuffered (or line-buffered when
a terminal is connected), but not in case of MSVCRT.
Explicitly calling setvbuf() like in this commit, makes the Windows
runtime behave like POSIX, giving the same “print immediately” behavior.

Signed-off-by: softworkz <softworkz@hotmail.com>