### PR TITLE
fftools/ffmpeg: Include elapsed-time in print_report()

### DIFF
--- a/fftools/ffmpeg.c
+++ b/fftools/ffmpeg.c
@@ -555,7 +555,7 @@ static void print_report(int is_last_report, int64_t timer_start, int64_t cur_ti
     static int64_t last_time = -1;
     static int first_report = 1;
     uint64_t nb_frames_dup = 0, nb_frames_drop = 0;
-    int mins, secs, us;
+    int mins, secs, ms, us;
     int64_t hours;
     const char *hours_sign;
     int ret;
@@ -579,6 +579,16 @@ static void print_report(int is_last_report, int64_t timer_start, int64_t cur_ti
     vid = 0;
     av_bprint_init(&buf, 0, AV_BPRINT_SIZE_AUTOMATIC);
     av_bprint_init(&buf_script, 0, AV_BPRINT_SIZE_AUTOMATIC);
+
+    secs = (int)t;
+    ms = (int)((t - secs) * 1000);
+    mins = secs / 60;
+    secs %= 60;
+    hours = mins / 60;
+    mins %= 60;
+
+    av_bprintf(&buf, "elapsed=%"PRId64":%02d:%02d.%02d ", hours, mins, secs, ms / 10);
+
     for (OutputStream *ost = ost_iter(NULL); ost; ost = ost_iter(ost)) {
         const float q = ost->enc ? atomic_load(&ost->quality) / (float) FF_QP2LAMBDA : -1;
 


### PR DESCRIPTION
It's a highly useful metric, both at runtime and when viewing logs.

Signed-off-by: softworkz <softworkz@hotmail.com>

## Versions

### V2

- Fix "new warning" detected by Patchwork
