### PR TITLE
fftools/ffmpeg: Log 'EXIT' on exit

### DIFF
--- a/fftools/ffmpeg.c
+++ b/fftools/ffmpeg.c
@@ -1012,5 +1012,8 @@ finish:
 
     sch_free(&sch);
 
+    av_log(NULL, AV_LOG_VERBOSE, "\n");
+    av_log(NULL, AV_LOG_VERBOSE, "Exiting with exit code %d\n", ret);
+
     return ret;
 }


### PR DESCRIPTION
When viewing logs, there are situations where it is not entirely
clear whether ffmpeg CLI has exited gracefully. The two primary cases
are

- A crash/segfault has occured
  Windows for example doesn't output any message to the calling shell
- The process has been terminated (e.g. killed externally)

Printing "EXIT" on exit provides a reliable indication that the
process has exited normally.

Signed-off-by: softworkz <softworkz@hotmail.com>

## Versions

## V2

- Include exit code in exit message as suggested by Marton Balint

