### PR TITLE
fftools/ffprobe: Print size of attachments

### DIFF
--- a/doc/ffprobe.xsd
+++ b/doc/ffprobe.xsd
@@ -319,6 +319,9 @@
     <xsd:attribute name="nb_frames"        type="xsd:int"/>
     <xsd:attribute name="nb_read_frames"   type="xsd:int"/>
     <xsd:attribute name="nb_read_packets"  type="xsd:int"/>
+
+    <!-- attachment attributes -->
+    <xsd:attribute name="attachment_size"  type="xsd:int"/>
   </xsd:complexType>
 
   <xsd:complexType name="programType">

--- a/fftools/ffprobe.c
+++ b/fftools/ffprobe.c
@@ -1847,6 +1847,10 @@ static int show_stream(AVTextFormatContext *tfc, AVFormatContext *fmt_ctx, int s
         else
             print_str_opt("height",  "N/A");
         break;
+
+    case AVMEDIA_TYPE_ATTACHMENT:
+        if (par->extradata_size)
+            print_int("attachment_size", par->extradata_size);
     }
 
     if (show_private_data) {


### PR DESCRIPTION
### Versions

#### V2

Fix spurious commit message text as noted by Andreas (thanks!)

#### V3

Also removed from the cover-letter part
