### PR TITLE
avformat/dump: Change precision of stream start offsets

### DIFF
--- a/libavformat/dump.c
+++ b/libavformat/dump.c
@@ -680,7 +680,7 @@ FF_ENABLE_DEPRECATION_WARNINGS
 
     if (st->start_time != AV_NOPTS_VALUE && st->start_time != 0 && st->time_base.den && st->time_base.num) {
         const double stream_start = av_q2d(st->time_base) * st->start_time;
-        av_log(NULL, AV_LOG_INFO, ", Start-Time %.3fs", stream_start);
+        av_log(NULL, AV_LOG_INFO, ", Start %.6f", stream_start);
     }
 
     dump_disposition(st->disposition, log_level);


### PR DESCRIPTION
Changing this to 6 digits to align with other
printed times

Signed-off-by: softworkz <softworkz@hotmail.com>

### Versions

#### V2

Following comments from Gyan and Marton:

- Change precision to 6 digits to align with other printed times
- Change label to just "Start"
- Add 's' unit to format 'start' value for consistency

#### V3

- Remove 's' unit


.
