### PR TITLE
ffbuild/commonmak: Fix rebuild check with implicit rule chains

### DIFF
--- a/ffbuild/common.mak
+++ b/ffbuild/common.mak
@@ -139,6 +139,10 @@ else
 	$(BIN2C) $(patsubst $(SRC_PATH)/%,$(SRC_LINK)/%,$<) $@ $(subst .,_,$(basename $(notdir $@)))
 endif
 
+%.ptx.o: %.ptx.c
+	$(CC) $(CCFLAGS) -x c -c -o $@ $<
+
+
 # 1) Preprocess CSS to a minified version
 %.css.min: %.css
 	# Must start with a tab in the real Makefile
@@ -176,6 +180,13 @@ else   # NO COMPRESSION
 %.html.c: %.html $(BIN2CEXE)
 	$(BIN2C) $< $@ $(subst .,_,$(basename $(notdir $@)))
 endif
+
+%.html.o: %.html.c
+	$(CC) $(CCFLAGS) -x c -c -o $@ $<
+
+%.css.o: %.css.c
+	$(CC) $(CCFLAGS) -x c -c -o $@ $<
+
 
 clean::
 	$(RM) $(BIN2CEXE) $(CLEANSUFFIXES:%=ffbuild/%)
@@ -228,11 +239,9 @@ ALLHEADERS := $(subst $(SRC_DIR)/,$(SUBDIR),$(wildcard $(SRC_DIR)/*.h $(SRC_DIR)
 SKIPHEADERS += $(ARCH_HEADERS:%=$(ARCH)/%) $(SKIPHEADERS-)
 SKIPHEADERS := $(SKIPHEADERS:%=$(SUBDIR)%)
 HOBJS        = $(filter-out $(SKIPHEADERS:.h=.h.o),$(ALLHEADERS:.h=.h.o))
-PTXOBJS      = $(filter %.ptx.o,$(OBJS))
-RESOURCEOBJS = $(filter %.css.o %.html.o,$(OBJS))
 $(HOBJS):     CCFLAGS += $(CFLAGS_HEADERS)
 checkheaders: $(HOBJS)
-.SECONDARY:   $(HOBJS:.o=.c) $(PTXOBJS:.o=.c) $(PTXOBJS:.o=.gz) $(PTXOBJS:.o=) $(RESOURCEOBJS:.o=.c) $(RESOURCEOBJS:%.css.o=%.css.min) $(RESOURCEOBJS:%.css.o=%.css.min.gz) $(RESOURCEOBJS:%.html.o=%.html.gz) $(RESOURCEOBJS:.o=)
+.SECONDARY:   $(HOBJS:.o=.c)
 
 alltools: $(TOOLS)
 


### PR DESCRIPTION
When there's a chain of implicit rules, make treats files generated
inside that chain as intermediate files. Those intermediate files are
removed after completion of make. When make is run again, it normally
determines the need for a rebuild by comparing the timestamps of the
original source file and the final output of the chain and if still
up-to-date, it doesn't rebuild, even when the intermediate files are
not present. That makes sense of course - why would it delete them
otherwise, it would end up in builds being never up-to-date.
But this original by-the-book logic appeared to be broken and has been
worked around by adding all intermediate files to the .SECONDARY
special target, which required extra logic and issues with make clean.

What broke the up-to-date checking is the dependency file generation.
For the .c files generated by BIN2C the compile target created a .d
file which indicated that the .ptx.o file has a dependency on the
ptx.c file. And that dependency broke the normal make behavior with
intermediate files.

This patch compiles the BIN2C generated .c files without generating
.d files. In turn the files do not longer need to be added to the
.SECONDARY target in common.mak.

When interested in those files for debugging, a line can be added to
the corresponding Makefile like

.SECONDARY: %.ptx.c %.ptx.gz

Signed-off-by: softworkz <softworkz@hotmail.com>