### PR TITLE
fftools/makefile: Remove resources from ffprobe

### DIFF
--- a/fftools/Makefile
+++ b/fftools/Makefile
@@ -49,7 +49,6 @@ OBJS-ffprobe +=                       \
     fftools/textformat/tw_avio.o      \
     fftools/textformat/tw_buffer.o    \
     fftools/textformat/tw_stdout.o    \
-    $(OBJS-resman)                    \
 
 OBJS-ffplay += fftools/ffplay_renderer.o
 


### PR DESCRIPTION
Even though it doesn't have any effect, that line is not needed (yet).

Signed-off-by: softworkz <softworkz@hotmail.com>