### PR TITLE
fftools/resman: remove redundant includes, use inflate loop

### DIFF
--- a/fftools/resources/resman.c
+++ b/fftools/resources/resman.c
@@ -34,7 +34,6 @@
 #include "resman.h"
 #include "fftools/ffmpeg_filter.h"
 #include "libavutil/avassert.h"
-#include "libavutil/pixdesc.h"
 #include "libavutil/dict.h"
 #include "libavutil/common.h"
 
@@ -61,7 +60,7 @@ typedef struct ResourceManagerContext {
 
 static AVMutex mutex = AV_MUTEX_INITIALIZER;
 
-ResourceManagerContext *resman_ctx = NULL;
+static ResourceManagerContext *resman_ctx = NULL;
 
 
 #if CONFIG_RESOURCE_COMPRESSION
@@ -77,7 +76,7 @@ static int decompress_gzip(ResourceManagerContext *ctx, uint8_t *in, unsigned in
     memset(&strm, 0, sizeof(strm));
 
     // Allocate output buffer with extra byte for null termination
-    buf = (uint8_t *)av_mallocz(chunk + 1);
+    buf = av_mallocz(chunk + 1);
     if (!buf) {
         av_log(ctx, AV_LOG_ERROR, "Failed to allocate decompression buffer\n");
         return AVERROR(ENOMEM);
@@ -156,7 +155,7 @@ void ff_resman_uninit(void)
 }
 
 
-char *ff_resman_get_string(FFResourceId resource_id)
+const char *ff_resman_get_string(FFResourceId resource_id)
 {
     ResourceManagerContext *ctx               = get_resman_context();
     FFResourceDefinition resource_definition = { 0 };

--- a/fftools/resources/resman.h
+++ b/fftools/resources/resman.h
@@ -21,14 +21,6 @@
 #ifndef FFTOOLS_RESOURCES_RESMAN_H
 #define FFTOOLS_RESOURCES_RESMAN_H
 
-#include <stdint.h>
-
-#include "config.h"
-#include "fftools/ffmpeg.h"
-#include "libavutil/avutil.h"
-#include "libavutil/bprint.h"
-#include "fftools/textformat/avtextformat.h"
-
 typedef enum {
     FF_RESOURCE_GRAPH_CSS,
     FF_RESOURCE_GRAPH_HTML,
@@ -45,6 +37,6 @@ typedef struct FFResourceDefinition {
 
 void ff_resman_uninit(void);
 
-char *ff_resman_get_string(FFResourceId resource_id);
+const char *ff_resman_get_string(FFResourceId resource_id);
 
 #endif /* FFTOOLS_RESOURCES_RESMAN_H */


### PR DESCRIPTION
and other cosmetic fixes.

As per review by Ramiro Polla in message:
"Re: [FFmpeg-devel] [FFmpeg-cvslog] fftools/resources: Add resource manager files with build-time compression"

V2

- Use two-pass decompression to return resources in actual-size memory buffers    
  (in response to comment by Kieran)


.