### PR TITLE
avformat/hlsenc: Some HLS improvements

### DIFF
--- a/libavformat/hlsenc.c
+++ b/libavformat/hlsenc.c
@@ -329,6 +329,29 @@ static int hlsenc_io_close(AVFormatContext *s, AVIOContext **pb, char *filename)
     return ret;
 }
 
+static ptrdiff_t get_last_separator_pos(const char *path)
+{
+    if (!path || *path == '\0')
+        return -1;
+
+    char *p = strrchr(path, '/');
+#if HAVE_DOS_PATHS
+    char *q = strrchr(path, '\\');
+    if (q) {
+        if (p) {
+            p = FFMAX(p, q);
+        } else {
+            p = q;
+        }
+    }
+#endif
+
+    if (!p)
+        return -1;
+
+    return p - path;
+}
+
 static void set_http_options(AVFormatContext *s, AVDictionary **options, HLSContext *c)
 {
     int http_base_proto = ff_is_http_proto(s->url);
@@ -1406,16 +1429,12 @@ static int hls_rename_temp_file(AVFormatContext *s, AVFormatContext *oc)
     return ret;
 }
 
-static const char* get_relative_url(const char *master_url, const char *media_url)
+static const char *get_relative_url(const char *master_url, const char *media_url)
 {
-    const char *p = strrchr(master_url, '/');
-    size_t base_len = 0;
+    ptrdiff_t pos = get_last_separator_pos(master_url);
 
-    if (!p) p = strrchr(master_url, '\\');
-
-    if (p) {
-        base_len = p - master_url;
-        if (av_strncasecmp(master_url, media_url, base_len)) {
+    if (pos >= 0) {
+        if (av_strncasecmp(master_url, media_url, pos)) {
             av_log(NULL, AV_LOG_WARNING, "Unable to find relative url\n");
             return NULL;
         }
@@ -1423,7 +1442,7 @@ static const char* get_relative_url(const char *master_url, const char *media_ur
         return media_url;
     }
 
-    return media_url + base_len + 1;
+    return media_url + pos + 1;
 }
 
 static int64_t get_stream_bit_rate(AVStream *stream)
@@ -3142,13 +3161,10 @@ static int hls_init(AVFormatContext *s)
                     vs->fmp4_init_filename = expanded;
                 }
 
-                p = strrchr(vs->m3u8_name, '/');
-                if (p) {
-                    char tmp = *(++p);
-                    *p = '\0';
-                    vs->base_output_dirname = av_asprintf("%s%s", vs->m3u8_name,
+                ptrdiff_t pos = get_last_separator_pos(vs->m3u8_name);
+                if (pos >= 0) {
+                    vs->base_output_dirname = av_asprintf("%.*s%s", pos + 1, vs->m3u8_name,
                                                           vs->fmp4_init_filename);
-                    *p = tmp;
                 } else {
                     vs->base_output_dirname = av_strdup(vs->fmp4_init_filename);
                 }


### PR DESCRIPTION
Includes only a single patch now:

- Fix path handling on Windows


## Versions

### V2

- Fix path handling for Windows;    
  - Keep using av_asprintf() with "%*s" to limit the length
    (as per review by Marton - thanks!)
  - Use int64:_t instead of int
- Removed logging patches

### V3

- Updated commit message
- Don't compare null pointers
- use ptrdiff_t
  (all as per review by Marton Balint - thanks!)

.